### PR TITLE
57 loader refactor

### DIFF
--- a/owlsim-core/pom.xml
+++ b/owlsim-core/pom.xml
@@ -189,7 +189,7 @@
 		<dependency>
 		    <groupId>org.prefixcommons</groupId>
 		    <artifactId>curie-util</artifactId>
-		    <version>0.0.1</version>
+		    <version>0.0.2</version>
 		</dependency>
 	</dependencies>
 

--- a/owlsim-core/src/main/java/org/monarchinitiative/owlsim/io/OWLLoader.java
+++ b/owlsim-core/src/main/java/org/monarchinitiative/owlsim/io/OWLLoader.java
@@ -1,15 +1,6 @@
 package org.monarchinitiative.owlsim.io;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.HashMap;
-import java.util.List;
-import java.util.zip.GZIPInputStream;
-
+import com.google.common.base.Preconditions;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.monarchinitiative.owlsim.kb.BMKnowledgeBase;
@@ -17,23 +8,22 @@ import org.monarchinitiative.owlsim.kb.impl.BMKnowledgeBaseOWLAPIImpl;
 import org.prefixcommons.CurieUtil;
 import org.semanticweb.elk.owlapi.ElkReasonerFactory;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLClassAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLDataFactory;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
-import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 
-import com.google.common.base.Preconditions;
+import java.io.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.zip.GZIPInputStream;
 
 /**
  * Object for loading OWL ontologies into a {@link BMKnowledgeBase}
  * 
  * Note that a KB consists of classes and individuals, both of which can be
  * loaded from an ontology
- * 
+ *
+ * @deprecated - Use the OwlKnowledgeBase.loader() instead.
  * @author cjm
  *
  */
@@ -52,7 +42,7 @@ public class OWLLoader {
 	 * @return OWL Ontology
 	 * @throws OWLOntologyCreationException
 	 */
-	public OWLOntology loadOWL(IRI iri) throws OWLOntologyCreationException {
+	private OWLOntology loadOWL(IRI iri) throws OWLOntologyCreationException {
 		return getOWLOntologyManager().loadOntology(iri);
 	}
 
@@ -61,7 +51,7 @@ public class OWLLoader {
 	 * @return OWL Ontology
 	 * @throws OWLOntologyCreationException
 	 */
-	public OWLOntology loadOWL(File file) throws OWLOntologyCreationException {
+	private OWLOntology loadOWL(File file) throws OWLOntologyCreationException {
 		IRI iri = IRI.create(file);
 		return getOWLOntologyManager().loadOntologyFromOntologyDocument(iri);
 	}
@@ -73,7 +63,7 @@ public class OWLLoader {
 	 * @return OWL Ontology
 	 * @throws OWLOntologyCreationException
 	 */
-	public OWLOntology loadOWL(String path) throws OWLOntologyCreationException {
+	private OWLOntology loadOWL(String path) throws OWLOntologyCreationException {
 		if (path.startsWith("http")) {
 			return loadOWL(IRI.create(path));
 		} else {

--- a/owlsim-core/src/main/java/org/monarchinitiative/owlsim/io/Ontology.java
+++ b/owlsim-core/src/main/java/org/monarchinitiative/owlsim/io/Ontology.java
@@ -1,0 +1,237 @@
+package org.monarchinitiative.owlsim.io;
+
+import org.apache.commons.validator.routines.UrlValidator;
+import org.apache.log4j.Logger;
+import org.prefixcommons.CurieUtil;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.model.parameters.ChangeApplied;
+import uk.ac.manchester.cs.owl.owlapi.concurrent.Concurrency;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * OWL API wrapper to facilitate building OWLOntology objects to load into the {@link org.monarchinitiative.owlsim.kb.impl.BMKnowledgeBaseOWLAPIImpl}
+ *
+ * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
+ */
+public class Ontology {
+
+    private static final Logger logger = Logger.getLogger(Ontology.class);
+
+    //OWLOntology is a mutable object
+    private final OntologySourceData sourceData;
+    private final CurieUtil curieUtil;
+    private final OWLOntology owlOntology;
+
+    private final OWLOntologyManager ontologyManager;
+
+    private Ontology(OntologySourceData sourceData, Concurrency concurrency) {
+        Objects.requireNonNull(sourceData, "Unable to create Ontology without data sources.");
+        this.sourceData = sourceData;
+        this.curieUtil = new CurieUtil(sourceData.getCuries());
+        this.ontologyManager = createOntologyManager(concurrency);
+        this.owlOntology = createEmptyOntology(ontologyManager);
+        loadOwlOntology();
+    }
+
+    /**
+     * Loads an ontology using a concurrent OWLOntologyManager.
+     *
+     * @param sourceData
+     * @return An Ontology created from the source data provided.
+     */
+    public static Ontology load(OntologySourceData sourceData) {
+        return new Ontology(sourceData, Concurrency.CONCURRENT);
+    }
+
+    /**
+     * Loads an ontology using an OWLOntologyManager using the concurrency type specified.
+     *
+     * @param sourceData
+     * @param concurrency
+     * @return An Ontology created from the source data provided.
+     */
+    public static Ontology load(OntologySourceData sourceData, Concurrency concurrency) {
+        return new Ontology(sourceData, useConcurrentIfNull(concurrency));
+    }
+
+    private static Concurrency useConcurrentIfNull(Concurrency concurrency) {
+        return concurrency == null ? Concurrency.CONCURRENT : concurrency;
+    }
+
+    public OWLOntology getOwlOntology() {
+        return owlOntology;
+    }
+
+    public OntologySourceData getSourceData() {
+        return sourceData;
+    }
+
+    public CurieUtil getCurieUtil() {
+        return curieUtil;
+    }
+
+    private void loadOwlOntology() {
+        //Order matters here - don't change it.
+        mergeOntologies(sourceData.getOntologies());
+        mergeOntologies(sourceData.getDataOntologies());
+        loadDataFromTsv(sourceData.getDataTsvs());
+        loadDataFromPairwiseMappings(sourceData.getPairwiseMappings());
+        logger.info("Ontology loaded");
+    }
+
+    private OWLOntologyManager createOntologyManager(Concurrency concurrencyType) {
+        if (concurrencyType == Concurrency.NON_CONCURRENT) {
+            logger.info("Using non-concurrent OWL ontology manager");
+            return OWLManager.createOWLOntologyManager();
+        }
+        logger.info("Using concurrent OWL ontology manager");
+        return OWLManager.createConcurrentOWLOntologyManager();
+    }
+
+    private OWLOntology createEmptyOntology(OWLOntologyManager ontologyManager) {
+        try {
+            return ontologyManager.createOntology();
+        } catch (OWLOntologyCreationException e) {
+            throw new OntologyLoadException(e);
+        }
+    }
+
+    private OWLOntology mergeOntology(String uri) {
+        OWLOntology loadedOntology = loadOwlOntology(uri);
+        addAxioms(loadedOntology.getAxioms());
+        return owlOntology;
+    }
+
+    private OWLOntology mergeOntologies(Collection<String> uris) {
+        uris.forEach(uri -> mergeOntology(uri));
+        return owlOntology;
+    }
+
+    private ChangeApplied addAxiom(OWLAxiom axiom) {
+        return ontologyManager.addAxiom(owlOntology, axiom);
+    }
+
+    private ChangeApplied addAxioms(Set<OWLAxiom> axioms) {
+        return ontologyManager.addAxioms(owlOntology, axioms);
+    }
+
+    private OWLOntology loadOwlOntology(String uri) {
+        UrlValidator urlValidator = UrlValidator.getInstance();
+        if (urlValidator.isValid(uri)) {
+            return loadRemoteOntology(IRI.create(uri));
+        } else if (uri.endsWith(".gz")) {
+            return loadGzippedOntology(Paths.get(uri));
+        } else {
+            return loadOwlOntologyFromDocument(Paths.get(uri));
+        }
+    }
+
+    private OWLOntology loadRemoteOntology(IRI iri) {
+        return loadOwlOntology(iri);
+    }
+
+    private OWLOntology loadGzippedOntology(Path path) {
+        logger.info("Loading gzipped ontology from " + path);
+        try (InputStream is = new GZIPInputStream(new FileInputStream(path.toFile()))) {
+            return loadOwlOntologyFromDocument(is);
+        } catch (IOException e) {
+            throw new OntologyLoadException(e);
+        }
+    }
+
+    private OWLOntology loadOwlOntology(IRI iri) {
+        try {
+            logger.info("Loading ontology from IRI" + iri.getShortForm());
+            return ontologyManager.loadOntology(iri);
+        } catch (OWLOntologyCreationException e) {
+            throw new OntologyLoadException(e);
+        }
+    }
+
+    private OWLOntology loadDataFromTsv(Collection<String> paths) {
+        paths.forEach(this::loadDataFromTsv);
+        return owlOntology;
+    }
+
+    private OWLOntology loadDataFromTsv(String path) {
+        if (path.endsWith(".gz")) {
+            return loadDataFromTsvGzip(path);
+        }
+        Path file = Paths.get(path);
+        logger.info("Reading tsv data from " + path);
+        try {
+            Files.lines(file).forEach(line -> loadLineIntoDataOntology(line));
+        } catch (IOException e) {
+            throw new OntologyLoadException(e);
+        }
+        return owlOntology;
+    }
+
+    private OWLOntology loadDataFromTsvGzip(String path) {
+        Path file = Paths.get(path);
+        logger.info("Reading gzipped tsv data from " + file);
+        try (GZIPInputStream gis = new GZIPInputStream(new FileInputStream(file.toFile()));
+             BufferedReader bf = new BufferedReader(new InputStreamReader(gis, Charset.forName("UTF-8")))
+        ) {
+            bf.lines().forEach(line -> loadLineIntoDataOntology(line));
+        } catch (IOException e) {
+            throw new OntologyLoadException(e);
+        }
+        return owlOntology;
+    }
+
+    private void loadDataFromPairwiseMappings(Map<String, String> pairwiseMappings) {
+        pairwiseMappings.forEach(this::addInstanceOf);
+    }
+
+    private void loadLineIntoDataOntology(String line) {
+        String[] vals = line.split("\t", 2);
+        String[] terms = vals[1].split(";");
+        for (String t : terms) {
+            addInstanceOf(vals[0], t);
+        }
+    }
+
+    private void addInstanceOf(String individual, String ontologyClass) {
+//                logger.info("Adding axiom " + individual + ": " + ontologyClass);
+        OWLDataFactory owlDataFactory = ontologyManager.getOWLDataFactory();
+        OWLClass owlClass = owlDataFactory.getOWLClass(toIri(ontologyClass));
+        OWLNamedIndividual owlNamedIndividual = owlDataFactory.getOWLNamedIndividual(toIri(individual));
+        OWLClassAssertionAxiom axiom = owlDataFactory.getOWLClassAssertionAxiom(owlClass, owlNamedIndividual);
+        addAxiom(axiom);
+    }
+
+    private IRI toIri(String id) {
+        return IRI.create(curieUtil.getIri(id).orElse(id));
+    }
+
+    private OWLOntology loadOwlOntologyFromDocument(Path path) {
+        try {
+            logger.info("Loading ontology from document " + path);
+            return ontologyManager.loadOntologyFromOntologyDocument(path.toFile());
+        } catch (OWLOntologyCreationException e) {
+            throw new OntologyLoadException(e);
+        }
+    }
+
+    private OWLOntology loadOwlOntologyFromDocument(InputStream is) {
+        try {
+            return ontologyManager.loadOntologyFromOntologyDocument(is);
+        } catch (OWLOntologyCreationException e) {
+            logger.error("Unable to create ontology" + e);
+            throw new OntologyLoadException(e);
+        }
+    }
+}
+

--- a/owlsim-core/src/main/java/org/monarchinitiative/owlsim/io/OntologyLoadException.java
+++ b/owlsim-core/src/main/java/org/monarchinitiative/owlsim/io/OntologyLoadException.java
@@ -1,0 +1,14 @@
+package org.monarchinitiative.owlsim.io;
+
+/**
+ * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
+ */
+class OntologyLoadException extends RuntimeException {
+
+    OntologyLoadException(String message) {
+        super(message);
+    }
+
+    OntologyLoadException(Exception e) {
+    }
+}

--- a/owlsim-core/src/main/java/org/monarchinitiative/owlsim/io/OntologySourceData.java
+++ b/owlsim-core/src/main/java/org/monarchinitiative/owlsim/io/OntologySourceData.java
@@ -1,0 +1,193 @@
+package org.monarchinitiative.owlsim.io;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.monarchinitiative.owlsim.kb.BMKnowledgeBase;
+import org.semanticweb.owlapi.model.OWLOntology;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * Simple container for storing the original data sources used for constructing the {@link OWLOntology} and the
+ * {@link BMKnowledgeBase}.
+ *
+ * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
+ */
+public class OntologySourceData {
+
+    private final List<String> ontologies;
+    private final List<String> dataOntologies;
+
+    private final Map<String, String> curies;
+    private final List<String> dataTsvs;
+    //TODO: add these so people can programmatically add individual assertions
+    private final Map<String, String> pairwiseMappings;
+
+    private OntologySourceData(Builder builder) {
+        this.ontologies = distinctImmutableListOf(builder.ontologies);
+        this.dataOntologies = distinctImmutableListOf(builder.dataOntologies);
+        this.curies = ImmutableMap.copyOf(builder.curies);
+        this.dataTsvs = distinctImmutableListOf(builder.dataTsvs);
+        this.pairwiseMappings = ImmutableMap.copyOf(builder.pairwiseMappings);
+    }
+
+    private ImmutableList<String> distinctImmutableListOf(List<String> list) {
+        return list.stream().distinct().collect(ImmutableList.toImmutableList());
+    }
+
+    public List<String> getOntologies() {
+        return ontologies;
+    }
+
+    public List<String> getDataOntologies() {
+        return dataOntologies;
+    }
+
+    public Map<String, String> getCuries() {
+        return curies;
+    }
+
+    public List<String> getDataTsvs() {
+        return dataTsvs;
+    }
+
+    public Map<String, String> getPairwiseMappings() {
+        return pairwiseMappings;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OntologySourceData that = (OntologySourceData) o;
+        return Objects.equals(ontologies, that.ontologies) &&
+                Objects.equals(dataOntologies, that.dataOntologies) &&
+                Objects.equals(curies, that.curies) &&
+                Objects.equals(dataTsvs, that.dataTsvs) &&
+                Objects.equals(pairwiseMappings, that.pairwiseMappings);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ontologies, dataOntologies, curies, dataTsvs, pairwiseMappings);
+    }
+
+    @Override
+    public String toString() {
+        return "OntologySourceData{" +
+                "ontologies=" + ontologies +
+                ", dataOntologies=" + dataOntologies +
+                ", curies=" + curies +
+                ", dataTsvs=" + dataTsvs +
+                ", pairwiseMappings=" + pairwiseMappings +
+                '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private List<String> ontologies = new ArrayList<>();
+        private List<String> dataOntologies = new ArrayList<>();
+        //Curies need to be supplied if people are adding data using TSV files or pairwise mappings using curies.
+        private Map<String, String> curies = Collections.emptyMap();
+        private List<String> dataTsvs = new ArrayList<>();
+        private Map<String, String> pairwiseMappings = Collections.emptyMap();
+
+        private Builder(){
+            //use the static method.
+        }
+
+        /**
+         * @param curies
+         * @return
+         */
+        public Builder curies(Map<String, String> curies) {
+            this.curies = curies;
+            return this;
+        }
+
+        /**
+         * Loads an OWL/OBO ontology from a file.
+         *
+         * @param file
+         */
+        public Builder ontology(File file) {
+            ontologies.add(file.getAbsolutePath());
+            return this;
+        }
+
+        /**
+         * Loads an OWL/OBO ontology from a path.
+         *
+         * @param path
+         */
+        public Builder ontology(String path) {
+            this.ontologies.add(path);
+            return this;
+        }
+
+        public Builder ontologies(String... paths) {
+            this.ontologies.addAll(Arrays.asList(paths));
+            return this;
+        }
+
+        /**
+         * Loads, and merges the OWL/OBO ontologies from the paths given. These can be remote, local uncompressed or
+         * gzipped.
+         *
+         * @param paths
+         */
+        public Builder ontologies(Collection<String> paths) {
+            this.ontologies.addAll(paths);
+            return this;
+        }
+
+
+        public Builder dataOntology(String path) {
+            this.dataOntologies.add(path);
+            return this;
+        }
+
+        public Builder dataOntologies(String... paths) {
+            this.dataOntologies.addAll(Arrays.asList(paths));
+            return this;
+        }
+
+        public Builder dataOntologies(Collection<String> paths) {
+            this.dataOntologies.addAll(paths);
+            return this;
+        }
+
+        public Builder dataTsv(String path) {
+            dataTsvs.add(path);
+            return this;
+        }
+
+        public Builder dataTsv(String... paths) {
+            dataTsvs.addAll(Arrays.asList(paths));
+            return this;
+        }
+
+        public Builder dataTsv(Collection<String> paths) {
+            dataTsvs.addAll(paths);
+            return this;
+        }
+
+        public OntologySourceData build() {
+            if(ontologies.isEmpty()) {
+                throw new OntologyLoadException("No ontology defined.");
+            }
+            if (curies.isEmpty() && hasNonOntologyData()) {
+                throw new OntologyLoadException("Cannot load TSV data sources or pairwise mappings when curies have not been defined.");
+            }
+            return new OntologySourceData(this);
+        }
+
+        private boolean hasNonOntologyData() {
+            return !dataTsvs.isEmpty() || !pairwiseMappings.isEmpty();
+        }
+    }
+}

--- a/owlsim-core/src/main/java/org/monarchinitiative/owlsim/io/OwlKnowledgeBase.java
+++ b/owlsim-core/src/main/java/org/monarchinitiative/owlsim/io/OwlKnowledgeBase.java
@@ -1,0 +1,162 @@
+package org.monarchinitiative.owlsim.io;
+
+import org.apache.log4j.Logger;
+import org.monarchinitiative.owlsim.kb.BMKnowledgeBase;
+import org.monarchinitiative.owlsim.kb.impl.BMKnowledgeBaseOWLAPIImpl;
+import org.semanticweb.elk.owlapi.ElkReasonerFactory;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
+import uk.ac.manchester.cs.owl.owlapi.concurrent.Concurrency;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * A convenience wrapper to enable easy loading of a {@link BMKnowledgeBase} from OWL ontologies and data files.
+ *
+ * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
+ */
+public abstract class OwlKnowledgeBase {
+
+    private static final Logger logger = Logger.getLogger(OwlKnowledgeBase.class);
+
+    private OwlKnowledgeBase() {
+        //class is uninstantiable
+    }
+
+    public static Loader loader() {
+        return new Loader();
+    }
+
+    public static class Loader {
+
+        private Concurrency concurrencyType = Concurrency.CONCURRENT;
+        private OWLReasonerFactory owlReasonerFactory = new ElkReasonerFactory();
+
+        //TODO: do we want to expose this or keep it here? Chris mentioned we might want a way of keeping track of what the original source data was.
+        //So this is where it is. It's so tightly coupled this is literally a conjoined twin at the moment.
+        private OntologySourceData.Builder sourceDataBuilder = OntologySourceData.builder();
+
+        private Loader() {
+            //uses the static load() method in the parent class
+        }
+
+        /**
+         * @param curies
+         * @return
+         */
+        public Loader loadCuries(Map<String, String> curies) {
+            sourceDataBuilder.curies(curies);
+            return this;
+        }
+
+        /**
+         * Loads an OWL/OBO ontology from a file.
+         *
+         * @param file
+         */
+        public Loader loadOntology(File file) {
+            sourceDataBuilder.ontology(file);
+            return this;
+        }
+
+        /**
+         * Loads an OWL/OBO ontology from a path.
+         *
+         * @param path
+         */
+        public Loader loadOntology(String path) {
+            sourceDataBuilder.ontology(path);
+            return this;
+        }
+
+        public Loader loadOntologies(String... paths) {
+            sourceDataBuilder.ontologies(paths);
+            return this;
+        }
+
+        /**
+         * Loads, and merges the OWL/OBO ontologies from the paths given. These can be remote, local uncompressed or
+         * gzipped.
+         *
+         * @param paths
+         */
+        public Loader loadOntologies(Collection<String> paths) {
+            sourceDataBuilder.ontologies(paths);
+            return this;
+        }
+
+        public Loader loadDataFromOntology(String path) {
+            sourceDataBuilder.dataOntology(path);
+            return this;
+        }
+
+        public Loader loadDataFromOntologies(String... paths) {
+            sourceDataBuilder.dataOntologies(paths);
+            return this;
+        }
+
+        public Loader loadDataFromOntologies(Collection<String> paths) {
+            sourceDataBuilder.dataOntologies(paths);
+            return this;
+        }
+
+        public Loader loadDataFromTsv(String path) {
+            sourceDataBuilder.dataTsv(path);
+            return this;
+        }
+
+        public Loader loadDataFromTsv(String... paths) {
+            sourceDataBuilder.dataTsv(paths);
+            return this;
+        }
+
+        public Loader loadDataFromTsv(Collection<String> paths) {
+            sourceDataBuilder.dataTsv(paths);
+            return this;
+        }
+
+        /**
+         * Creates an {@link OWLOntologyManager} that is configured with the standard parsers and storers and provides
+         * locking for concurrent access (default).
+         */
+        public Loader useConcurrentOntologyManager() {
+            concurrencyType = Concurrency.CONCURRENT;
+            return this;
+        }
+
+        /**
+         * Creates an {@link OWLOntologyManager} that is configured with standard parsers,
+         * storers etc.
+         */
+        public Loader useStandardOntologyManager() {
+            concurrencyType = Concurrency.NON_CONCURRENT;
+            return this;
+        }
+
+        /**
+         * Allows overriding of the default {@link ElkReasonerFactory}
+         *
+         * @param owlReasonerFactory a concrete implementation of the {@link OWLReasonerFactory}
+         */
+        public Loader useReasonerFactory(OWLReasonerFactory owlReasonerFactory) {
+            this.owlReasonerFactory = owlReasonerFactory;
+            return this;
+        }
+
+        /**
+         * @return handle for a Bitmap-based Knowledge Base
+         */
+        public BMKnowledgeBase createKnowledgeBase() {
+
+            OntologySourceData sourceData = sourceDataBuilder.build();
+            Ontology ontology = Ontology.load(sourceData, concurrencyType);
+
+            return BMKnowledgeBaseOWLAPIImpl.create(ontology, owlReasonerFactory);
+        }
+
+    }
+
+
+}

--- a/owlsim-core/src/main/java/org/monarchinitiative/owlsim/io/OwlKnowledgeBase.java
+++ b/owlsim-core/src/main/java/org/monarchinitiative/owlsim/io/OwlKnowledgeBase.java
@@ -17,7 +17,7 @@ import java.util.Map;
  *
  * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
  */
-public abstract class OwlKnowledgeBase {
+public final class OwlKnowledgeBase {
 
     private static final Logger logger = Logger.getLogger(OwlKnowledgeBase.class);
 
@@ -57,6 +57,7 @@ public abstract class OwlKnowledgeBase {
          * @param file
          */
         public Loader loadOntology(File file) {
+            Math.random();
             sourceDataBuilder.ontology(file);
             return this;
         }

--- a/owlsim-core/src/main/java/org/monarchinitiative/owlsim/kb/filter/FilterEngine.java
+++ b/owlsim-core/src/main/java/org/monarchinitiative/owlsim/kb/filter/FilterEngine.java
@@ -1,13 +1,12 @@
 package org.monarchinitiative.owlsim.kb.filter;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
+import com.googlecode.javaewah.EWAHCompressedBitmap;
 import org.apache.log4j.Logger;
 import org.monarchinitiative.owlsim.kb.BMKnowledgeBase;
 
-import com.googlecode.javaewah.EWAHCompressedBitmap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Applies a {@link Filter} on a set of individuals.
@@ -92,7 +91,7 @@ public class FilterEngine {
             else {
                 typesBM = knowledgeBase.getTypesBM(id);
             }
-            LOG.info("typeId = " + tf.getTypeId());
+//            LOG.info("typeId = " + tf.getTypeId());
             int ix = knowledgeBase.getClassIndex(tf.getTypeId());
             return typesBM.getPositions().contains(ix) ^ tf.isNegated();
 		}

--- a/owlsim-core/src/main/java/org/monarchinitiative/owlsim/kb/impl/BMKnowledgeBaseOWLAPIImpl.java
+++ b/owlsim-core/src/main/java/org/monarchinitiative/owlsim/kb/impl/BMKnowledgeBaseOWLAPIImpl.java
@@ -1,13 +1,6 @@
 package org.monarchinitiative.owlsim.kb.impl;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.log4j.Logger;
@@ -51,7 +44,6 @@ import org.semanticweb.owlapi.reasoner.NodeSet;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.googlecode.javaewah.EWAHCompressedBitmap;
 import com.hp.hpl.jena.query.Query;
@@ -1082,7 +1074,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
     if (curieUtil.getCurieMap().isEmpty()) {
       return getOWLClass(IRI.create(id));
     } else {
-      return getOWLClass(IRI.create(curieUtil.getIri(id).or(id)));
+      return getOWLClass(IRI.create(curieUtil.getIri(id).orElse(id)));
     }
   }
 
@@ -1111,7 +1103,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
     if (curieUtil.getCurieMap().isEmpty()) {
       return getOWLNamedIndividual(IRI.create(id));
     } else {
-      return getOWLNamedIndividual(IRI.create(curieUtil.getIri(id).or(id)));
+      return getOWLNamedIndividual(IRI.create(curieUtil.getIri(id).orElse(id)));
     }
   }
 

--- a/owlsim-core/src/main/java/org/monarchinitiative/owlsim/kb/impl/BMKnowledgeBaseOWLAPIImpl.java
+++ b/owlsim-core/src/main/java/org/monarchinitiative/owlsim/kb/impl/BMKnowledgeBaseOWLAPIImpl.java
@@ -1,13 +1,6 @@
 package org.monarchinitiative.owlsim.kb.impl;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.log4j.Logger;
@@ -49,7 +42,6 @@ import org.semanticweb.owlapi.reasoner.NodeSet;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.googlecode.javaewah.EWAHCompressedBitmap;
 import com.hp.hpl.jena.query.Query;
@@ -100,7 +92,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 	// private Set<OWLClass> classesInSignature;
 	private Set<OWLNamedIndividual> individualsInSignature;
 	private Map<String, Map<String, Set<Object>>> propertyValueMapMap;
-	Map<OWLClass, Set<OWLClassExpression>> opposingClassMap = new HashMap<OWLClass, Set<OWLClassExpression>>();
+	Map<OWLClass, Set<OWLClassExpression>> opposingClassMap = new HashMap<>();
 
 	private int[] individualCountPerClassArray;
 
@@ -187,7 +179,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 		}
 		if (n == 0) {
 			LOG.info("Setting labels from fragments");
-			Set<OWLNamedObject> objs = new HashSet<OWLNamedObject>();
+			Set<OWLNamedObject> objs = new HashSet<>();
 			objs.addAll(ontology.getClassesInSignature());
 			objs.addAll(ontology.getIndividualsInSignature());
 			for (OWLNamedObject obj : objs) {
@@ -216,7 +208,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 	 * @return set of all class identifiers
 	 */
 	public Set<String> getClassIdsInSignature() {
-		Set<String> ids = new HashSet<String>();
+		Set<String> ids = new HashSet<>();
 		for (OWLClass i : getClassesInSignature()) {
 			ids.add(getShortForm(i.getIRI()));
 		}
@@ -252,7 +244,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 	 * @return ids
 	 */
 	public Set<String> getIndividualIdsInSignature() {
-		Set<String> ids = new HashSet<String>();
+		Set<String> ids = new HashSet<>();
 		for (OWLNamedIndividual i : getIndividualsInSignature()) {
 			ids.add(getShortForm(i.getIRI()));
 		}
@@ -284,8 +276,8 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 	// Each OWLClass and OWLIndividual is mapped to an Integer index
 	private void createMap() {
 		LOG.info("Creating mapping from ontology objects to integers");
-		classNodes = new HashSet<Node<OWLClass>>();
-		individualNodes = new HashSet<Node<OWLNamedIndividual>>();
+		classNodes = new HashSet<>();
+		individualNodes = new HashSet<>();
 		Set<OWLClass> classesInSignature;
 		classesInSignature = owlOntology.getClassesInSignature(true);
 		LOG.info("|classes|=" + classesInSignature.size());
@@ -293,13 +285,13 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 		classesInSignature.remove(getOWLNothing());
 		individualsInSignature = owlOntology.getIndividualsInSignature(true);
 		LOG.info("|individuals|=" + individualsInSignature.size());
-		classToNodeMap = new HashMap<OWLClass, Node<OWLClass>>();
-		individualToNodeMap = new HashMap<OWLNamedIndividual, Node<OWLNamedIndividual>>();
-		classNodeToIntegerMap = new HashMap<Node<OWLClass>, Integer>();
-		individualNodeToIntegerMap = new HashMap<Node<OWLNamedIndividual>, Integer>();
-		propertyValueMapMap = new HashMap<String, Map<String, Set<Object>>>();
-		final HashMap<Node<OWLClass>, Integer> classNodeToFrequencyMap = new HashMap<Node<OWLClass>, Integer>();
-		final HashMap<Node<OWLClass>, Double> classNodeToFreqDepthMap = new HashMap<Node<OWLClass>, Double>();
+		classToNodeMap = new HashMap<>();
+		individualToNodeMap = new HashMap<>();
+		classNodeToIntegerMap = new HashMap<>();
+		individualNodeToIntegerMap = new HashMap<>();
+		propertyValueMapMap = new HashMap<>();
+		final HashMap<Node<OWLClass>, Integer> classNodeToFrequencyMap = new HashMap<>();
+		final HashMap<Node<OWLClass>, Double> classNodeToFreqDepthMap = new HashMap<>();
 		for (OWLClass c : classesInSignature) {
 			if (owlReasoner.getInstances(c, false).isEmpty()) {
 				// TODO: deal with subclasses
@@ -346,17 +338,15 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 		// Content)
 		// nodes are have LOWER indices
 		// TODO: use depth as a tie breaker
-		List<Node<OWLClass>> classNodesSorted = new ArrayList<Node<OWLClass>>(classNodes);
-		Collections.sort(classNodesSorted, new Comparator<Node<OWLClass>>() {
-			public int compare(Node<OWLClass> n1, Node<OWLClass> n2) {
-				double f1 = classNodeToFreqDepthMap.get(n1);
-				double f2 = classNodeToFreqDepthMap.get(n2);
-				if (f1 < f2)
-					return -1;
-				if (f1 > f2)
-					return 1;
-				return 0;
-			}
+		List<Node<OWLClass>> classNodesSorted = new ArrayList<>(classNodes);
+		classNodesSorted.sort((n1, n2) -> {
+			double f1 = classNodeToFreqDepthMap.get(n1);
+			double f2 = classNodeToFreqDepthMap.get(n2);
+			if (f1 < f2)
+				return -1;
+			if (f1 > f2)
+				return 1;
+			return 0;
 		});
 		int numClassNodes = classNodesSorted.size();
 		classNodeArray = classNodesSorted.toArray(new Node[numClassNodes]);
@@ -378,7 +368,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 
 	private void setPropertyValues(OWLOntology ont, OWLNamedIndividual i) {
 		Preconditions.checkNotNull(i);
-		Map<String, Set<Object>> pvm = new HashMap<String, Set<Object>>();
+		Map<String, Set<Object>> pvm = new HashMap<>();
 		String id = getShortForm(i.getIRI());
 		propertyValueMapMap.put(id, pvm);
 		for (OWLIndividualAxiom ax : ont.getAxioms(i)) {
@@ -418,7 +408,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 	private void addPropertyValue(Map<String, Set<Object>> pvm, String pid, String v) {
 		// LOG.debug("PV="+pid+"="+v);
 		if (!pvm.containsKey(pid))
-			pvm.put(pid, new HashSet<Object>());
+			pvm.put(pid, new HashSet<>());
 		pvm.get(pid).add(v);
 	}
 
@@ -430,7 +420,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 
 	private void addOpposingClassPairAsym(OWLClass c, OWLClassExpression d) {
 		if (!opposingClassMap.containsKey(c))
-			opposingClassMap.put(c, new HashSet<OWLClassExpression>());
+			opposingClassMap.put(c, new HashSet<>());
 		opposingClassMap.get(c).add(d);
 	}
 
@@ -476,7 +466,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 
 			// direct individuals are those asserted to be of type c or anything
 			// equivalent to c
-			Set<Integer> individualInts = new HashSet<Integer>();
+			Set<Integer> individualInts = new HashSet<>();
 			for (OWLClass ec : owlReasoner.getEquivalentClasses(c).getEntities()) {
 				for (OWLClassAssertionAxiom ax : owlOntology.getClassAssertionAxioms(ec)) {
 					if (ax.getIndividual().isNamed()) {
@@ -494,8 +484,8 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 			ontoEWAHStore.setTypes(individualIndex, getIntegersForClassSet(owlReasoner.getTypes(i, false)));
 
 			// Treat CLassAssertion( ComplementOf(c) i) as a negative assertion
-			Set<Integer> ncs = new HashSet<Integer>();
-			Set<Integer> ncsDirect = new HashSet<Integer>();
+			Set<Integer> ncs = new HashSet<>();
+			Set<Integer> ncsDirect = new HashSet<>();
 			for (OWLClassAssertionAxiom cx : owlOntology.getClassAssertionAxioms(i)) {
 				// TODO: investigate efficiency - number of items set may be
 				// high
@@ -595,7 +585,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 	}
 
 	private Set<Integer> getIntegersForClassSet(NodeSet<OWLClass> nodeset) {
-		Set<Integer> bits = new HashSet<Integer>();
+		Set<Integer> bits = new HashSet<>();
 		for (Node<OWLClass> n : nodeset.getNodes()) {
 			if (n.contains(getOWLNothing()))
 				continue;
@@ -605,7 +595,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 	}
 
 	private Set<Integer> getIntegersForIndividualSet(NodeSet<OWLNamedIndividual> nodeset) {
-		Set<Integer> bits = new HashSet<Integer>();
+		Set<Integer> bits = new HashSet<>();
 		for (Node<OWLNamedIndividual> n : nodeset.getNodes()) {
 			bits.add(getIndexForIndividualNode(n));
 		}
@@ -702,7 +692,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 
 	public Set<String> getClassIds(int index) {
 		Node<OWLClass> n = getClassNode(index);
-		Set<String> cids = new HashSet<String>();
+		Set<String> cids = new HashSet<>();
 		for (OWLClass c : n.getEntities()) {
 			cids.add(getShortForm(c.getIRI()));
 		}
@@ -710,7 +700,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 	}
 
 	public Set<String> getClassIds(EWAHCompressedBitmap bm) {
-		Set<String> cids = new HashSet<String>();
+		Set<String> cids = new HashSet<>();
 		for (int x : bm) {
 			Node<OWLClass> n = getClassNode(x);
 			for (OWLClass c : n.getEntities()) {
@@ -799,7 +789,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 	 *         class
 	 */
 	protected EWAHCompressedBitmap getSuperClassesBMByOWLClassSet(Set<OWLClass> clsSet) {
-		Set<Integer> classIndices = new HashSet<Integer>();
+		Set<Integer> classIndices = new HashSet<>();
 		for (OWLClass c : clsSet) {
 			classIndices.add(getIndex(c));
 		}
@@ -847,7 +837,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 	 * @return union of all subClasses (direct and indirect) of any input class
 	 */
 	public EWAHCompressedBitmap getSubClassesBM(Set<String> clsIds) {
-		Set<Integer> classIndices = new HashSet<Integer>();
+		Set<Integer> classIndices = new HashSet<>();
 		for (String id : clsIds) {
 			classIndices.add(getClassIndex(id));
 		}
@@ -859,7 +849,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 	 * @return union of all direct subClasses of all input classes
 	 */
 	public EWAHCompressedBitmap getDirectSubClassesBM(Set<String> clsIds) {
-		Set<Integer> classIndices = new HashSet<Integer>();
+		Set<Integer> classIndices = new HashSet<>();
 		for (String id : clsIds) {
 			classIndices.add(getClassIndex(id));
 		}
@@ -872,7 +862,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 	 *         class
 	 */
 	public EWAHCompressedBitmap getSuperClassesBM(Set<String> clsIds) {
-		Set<Integer> classIndices = new HashSet<Integer>();
+		Set<Integer> classIndices = new HashSet<>();
 		for (String id : clsIds) {
 			classIndices.add(getClassIndex(id));
 		}
@@ -1016,7 +1006,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 		if (curieUtil.getCurieMap().isEmpty()) {
 			return getOWLClass(IRI.create(id));
 		} else {
-			return getOWLClass(IRI.create(curieUtil.getIri(id).or(id)));
+			return getOWLClass(IRI.create(curieUtil.getIri(id).orElse(id)));
 		}
 	}
 
@@ -1046,7 +1036,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 		if (curieUtil.getCurieMap().isEmpty()) {
 			return getOWLNamedIndividual(IRI.create(id));
 		} else {
-			return getOWLNamedIndividual(IRI.create(curieUtil.getIri(id).or(id)));
+			return getOWLNamedIndividual(IRI.create(curieUtil.getIri(id).orElse(id)));
 		}
 	}
 
@@ -1075,7 +1065,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 	public Set<Object> getPropertyValues(String individualId, String property) {
 		Map<String, Set<Object>> m = getPropertyValueMap(individualId);
 		if (m.containsKey(property))
-			return new HashSet<Object>(m.get(property));
+			return new HashSet<>(m.get(property));
 		else
 			return Collections.emptySet();
 	}
@@ -1099,7 +1089,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 	@Override
 	public EWAHCompressedBitmap getFilteredTypesBM(Set<String> ids, String classId) {
 
-		Set<Integer> classBits = new HashSet<Integer>();
+		Set<Integer> classBits = new HashSet<>();
 		for (String id : ids) {
 			classBits.add(this.getClassIndex(id));
 		}
@@ -1110,7 +1100,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 
 	public EWAHCompressedBitmap getFilteredDirectTypesBM(Set<String> classIds, String classId) {
 
-		Set<Integer> classBits = new HashSet<Integer>();
+		Set<Integer> classBits = new HashSet<>();
 		for (String id : classIds) {
 			classBits.add(this.getClassIndex(id));
 		}

--- a/owlsim-core/src/main/java/org/monarchinitiative/owlsim/kb/impl/BMKnowledgeBaseOWLAPIImpl.java
+++ b/owlsim-core/src/main/java/org/monarchinitiative/owlsim/kb/impl/BMKnowledgeBaseOWLAPIImpl.java
@@ -1,10 +1,13 @@
 package org.monarchinitiative.owlsim.kb.impl;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.log4j.Logger;
 import org.monarchinitiative.owlsim.io.OWLLoader;
+import org.monarchinitiative.owlsim.io.Ontology;
 import org.monarchinitiative.owlsim.kb.BMKnowledgeBase;
 import org.monarchinitiative.owlsim.kb.CURIEMapper;
 import org.monarchinitiative.owlsim.kb.LabelMapper;
@@ -72,460 +75,437 @@ import com.hp.hpl.jena.rdf.model.Resource;
  */
 public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
 
-  private Logger LOG = Logger.getLogger(BMKnowledgeBaseOWLAPIImpl.class);
+	private Logger LOG = Logger.getLogger(BMKnowledgeBaseOWLAPIImpl.class);
 
-  private KBMetadata kbMetdata;
+	private KBMetadata kbMetdata;
 
-  private EWAHKnowledgeBaseStore ontoEWAHStore;
-  private OWLOntology owlOntology;
-  private OWLOntology owlDataOntology;
-  private OWLReasoner owlReasoner;
+	private EWAHKnowledgeBaseStore ontoEWAHStore;
+	private OWLOntology owlOntology;
+	private OWLOntology owlDataOntology;
+	private OWLReasoner owlReasoner;
 
-  private Map<Node<OWLClass>, Integer> classNodeToIntegerMap;
-  private Node<OWLClass>[] classNodeArray;
-  private Map<Node<OWLNamedIndividual>, Integer> individualNodeToIntegerMap;
-  private Node<OWLNamedIndividual>[] individualNodeArray;
+	private Map<Node<OWLClass>, Integer> classNodeToIntegerMap;
+	private Node<OWLClass>[] classNodeArray;
+	private Map<Node<OWLNamedIndividual>, Integer> individualNodeToIntegerMap;
+	private Node<OWLNamedIndividual>[] individualNodeArray;
 
-  private Set<Node<OWLClass>> classNodes;
-  private Set<Node<OWLNamedIndividual>> individualNodes;
+	private Set<Node<OWLClass>> classNodes;
+	private Set<Node<OWLNamedIndividual>> individualNodes;
 
-  private Map<OWLClass, Node<OWLClass>> classToNodeMap;
-  private Map<OWLNamedIndividual, Node<OWLNamedIndividual>> individualToNodeMap;
-  // private Set<OWLClass> classesInSignature;
-  private Set<OWLNamedIndividual> individualsInSignature;
-  private Map<String, Map<String, Set<Object>>> propertyValueMapMap;
-  Map<OWLClass, Set<OWLClassExpression>> opposingClassMap =
-      new HashMap<OWLClass, Set<OWLClassExpression>>();
-  
-  Map<Integer, Map<Integer, Integer>> individualToWeightedDirectTypeMap = new HashMap<>();
+	private Map<OWLClass, Node<OWLClass>> classToNodeMap;
+	private Map<OWLNamedIndividual, Node<OWLNamedIndividual>> individualToNodeMap;
+	// private Set<OWLClass> classesInSignature;
+	private Set<OWLNamedIndividual> individualsInSignature;
+	private Map<String, Map<String, Set<Object>>> propertyValueMapMap;
+	private Map<OWLClass, Set<OWLClassExpression>> opposingClassMap = new HashMap<>();
 
+	private Map<Integer, Map<Integer, Integer>> individualToWeightedDirectTypeMap = new HashMap<>();
 
-  private int[] individualCountPerClassArray;
+	private int[] individualCountPerClassArray;
 
-  CURIEMapper curieMapper;
-  LabelMapper labelMapper;
-  CurieUtil curieUtil;
+	private CURIEMapper curieMapper;
+	private LabelMapper labelMapper;
+	private CurieUtil curieUtil;
 
-  /**
-   * @param owlOntology
-   * @param owlDataOntology TODO - fix this
-   * @param rf
-   */
-  public BMKnowledgeBaseOWLAPIImpl(OWLOntology owlOntology,
-      OWLOntology owlDataOntology, OWLReasonerFactory rf,
-      CurieUtil curieUtil) {
-    super();
-    curieMapper = new CURIEMapperImpl();
-    labelMapper = new LabelMapperImpl(curieMapper);
+	/**
+	 * @deprecated - use the create() constructor method with the single owlOntology - this should contain all the required axioms.
+	 * @param owlOntology
+	 * @param owlDataOntology
+	 *            TODO - fix this
+	 * @param reasonerFactory
+	 */
+	public BMKnowledgeBaseOWLAPIImpl(OWLOntology owlOntology, OWLOntology owlDataOntology, OWLReasonerFactory reasonerFactory, CurieUtil curieUtil) {
+		Objects.requireNonNull(owlOntology, "OWLOntology required - cannot be null.");
+		Objects.requireNonNull(reasonerFactory, "OWLReasonerFactory required, cannot be null.");
+		Objects.requireNonNull(curieUtil, "CurieUtil required - cannot be null");
 
-    this.owlOntology = owlOntology;
-    this.owlDataOntology = owlDataOntology;
-    if (owlDataOntology != null) {
-      translateFromDataOntology();
-    }
-    this.owlReasoner = rf.createReasoner(owlOntology);
-    this.curieUtil = curieUtil;
-    createMap();
-    ontoEWAHStore = new EWAHKnowledgeBaseStore(classNodes.size(), individualNodes.size());
-    storeInferences();
-    populateLabelsFromOntology(labelMapper, owlOntology);
-    if (owlDataOntology != null) {
-      LOG.info("Fetching labels from " + owlDataOntology);
-      // the data ontology may contain labels of data items
-      populateLabelsFromOntology(labelMapper, owlDataOntology);
-    }
-  }
+		Instant start = Instant.now();
+		curieMapper = new CURIEMapperImpl();
+		labelMapper = new LabelMapperImpl(curieMapper);
 
-  public static BMKnowledgeBase create(OWLOntology owlOntology, OWLReasonerFactory rf,
-      CurieUtil curieUtil) {
-    return new BMKnowledgeBaseOWLAPIImpl(owlOntology, null, rf, curieUtil);
-  }
+		this.owlOntology = owlOntology;
+		this.owlDataOntology = owlDataOntology;
+		if (owlDataOntology != null) {
+			translateFromDataOntology();
+		}
+		LOG.info("Creating OWL reasoner");
+		this.owlReasoner = reasonerFactory.createReasoner(owlOntology);
+		this.curieUtil = curieUtil;
+		createMap();
+		ontoEWAHStore = new EWAHKnowledgeBaseStore(classNodes.size(), individualNodes.size());
+		storeInferences();
+		populateLabelsFromOntology(labelMapper, owlOntology);
+		if (owlDataOntology != null) {
+			LOG.info("Fetching labels from " + owlDataOntology);
+			// the data ontology may contain labels of data items
+			populateLabelsFromOntology(labelMapper, owlDataOntology);
+		}
+		Instant end = Instant.now();
+		LOG.info("Knowledgebase loaded in " + Duration.between(start, end).toMillis() + " ms");
+	}
 
-  /**
-   * @param owlOntology
-   * @param owlDataOntology
-   * @param rf
-   * @return
-   */
-  public static BMKnowledgeBase create(OWLOntology owlOntology, OWLOntology owlDataOntology,
-      OWLReasonerFactory rf, CurieUtil curieUtil) {
-    return new BMKnowledgeBaseOWLAPIImpl(owlOntology, owlDataOntology, rf, curieUtil);
-  }
+	public static BMKnowledgeBase create(Ontology ontology, OWLReasonerFactory owlReasonerFactory) {
+		return new BMKnowledgeBaseOWLAPIImpl(ontology.getOwlOntology(), null, owlReasonerFactory, ontology.getCurieUtil());
+	}
 
+	public static BMKnowledgeBase create(OWLOntology owlOntology, OWLReasonerFactory rf, CurieUtil curieUtil) {
+		return new BMKnowledgeBaseOWLAPIImpl(owlOntology, null, rf, curieUtil);
+	}
 
+	/**
+	 * @deprecated
+	 * @param owlOntology
+	 * @param owlDataOntology
+	 * @param rf
+	 * @return
+	 */
+	public static BMKnowledgeBase create(OWLOntology owlOntology, OWLOntology owlDataOntology, OWLReasonerFactory rf, CurieUtil curieUtil) {
+		return new BMKnowledgeBaseOWLAPIImpl(owlOntology, owlDataOntology, rf, curieUtil);
+	}
 
-  public KBMetadata getKbMetdata() {
-    return kbMetdata;
-  }
+	public KBMetadata getKbMetdata() {
+		return kbMetdata;
+	}
 
+	public void setKbMetdata(KBMetadata kbMetdata) {
+		this.kbMetdata = kbMetdata;
+	}
 
+	private String getShortForm(IRI iri) {
+		if (curieUtil.getCurieMap().isEmpty()) {
+			return iri.toString();
+		} else {
+			String iriString = iri.toString();
+			return curieUtil.getCurie(iriString).orElse(iriString);
+		}
+	}
 
-  public void setKbMetdata(KBMetadata kbMetdata) {
-    this.kbMetdata = kbMetdata;
-  }
+	private void populateLabelsFromOntology(LabelMapper labelMapper, OWLOntology ontology) {
+		LOG.info("Populating labels from " + ontology);
+		int n = 0;
+		for (OWLAnnotationAssertionAxiom aaa : ontology.getAxioms(AxiomType.ANNOTATION_ASSERTION)) {
+			if (aaa.getProperty().isLabel()) {
+				if (aaa.getSubject() instanceof IRI && aaa.getValue() instanceof OWLLiteral) {
+					labelMapper.add(getShortForm((IRI) aaa.getSubject()), ((OWLLiteral) aaa.getValue()).getLiteral());
+					n++;
+				}
+			}
+		}
+		if (n == 0) {
+			LOG.info("Setting labels from fragments");
+			Set<OWLNamedObject> objs = new HashSet<>();
+			objs.addAll(ontology.getClassesInSignature());
+			objs.addAll(ontology.getIndividualsInSignature());
+			for (OWLNamedObject obj : objs) {
+				labelMapper.add(getShortForm(obj.getIRI()), obj.getIRI().getFragment());
+				n++;
+			}
+		}
+		LOG.info("Label axioms mapped: " + n);
+	}
 
-  private String getShortForm(IRI iri) {
-    if (curieUtil.getCurieMap().isEmpty()) {
-      return iri.toString();
-    } else {
-        Optional<String> curie = curieUtil.getCurie(iri.toString());
-        if (curie.isPresent()) {
-            return curie.get();
-        }
-        else {
-            return iri.toString();
-        }
-    }
-  }
+	/**
+	 * @return utility object to map labels to ids
+	 */
+	public LabelMapper getLabelMapper() {
+		return labelMapper;
+	}
 
-  private void populateLabelsFromOntology(LabelMapper labelMapper, OWLOntology ontology) {
-    LOG.info("Populating labels from " + ontology);
-    int n = 0;
-    for (OWLAnnotationAssertionAxiom aaa : ontology.getAxioms(AxiomType.ANNOTATION_ASSERTION)) {
-      if (aaa.getProperty().isLabel()) {
-        if (aaa.getSubject() instanceof IRI && aaa.getValue() instanceof OWLLiteral) {
-          labelMapper.add(getShortForm((IRI) aaa.getSubject()),
-              ((OWLLiteral) aaa.getValue()).getLiteral());
-          n++;
-        }
-      }
-    }
-    if (n == 0) {
-      LOG.info("Setting labels from fragments");
-      Set<OWLNamedObject> objs = new HashSet<OWLNamedObject>();
-      objs.addAll(ontology.getClassesInSignature());
-      objs.addAll(ontology.getIndividualsInSignature());
-      for (OWLNamedObject obj : objs) {
-        labelMapper.add(getShortForm(obj.getIRI()), obj.getIRI().getFragment());
-        n++;
-      }
-    }
-    LOG.info("Label axioms mapped: " + n);
-  }
+	/**
+	 * @return set of all classes
+	 */
+	public Set<OWLClass> getClassesInSignature() {
+		return classToNodeMap.keySet(); // TODO - consider optimizing
+	}
 
-  /**
-   * @return utility object to map labels to ids
-   */
-  public LabelMapper getLabelMapper() {
-    return labelMapper;
-  }
+	/**
+	 * @return set of all class identifiers
+	 */
+	public Set<String> getClassIdsInSignature() {
+		Set<String> ids = new HashSet<>();
+		for (OWLClass i : getClassesInSignature()) {
+			ids.add(getShortForm(i.getIRI()));
+		}
+		return ids;
+	}
 
-  /**
-   * @return set of all classes
-   */
-  public Set<OWLClass> getClassesInSignature() {
-    return classToNodeMap.keySet(); // TODO - consider optimizing
-  }
+	public Set<String> getClassIdsByOntology(String ont) {
+		return getClassIdsInSignature().stream().filter(x -> isIn(x, ont)).collect(Collectors.toSet());
+	}
 
-  /**
-   * @return set of all class identifiers
-   */
-  public Set<String> getClassIdsInSignature() {
-    Set<String> ids = new HashSet<String>();
-    for (OWLClass i : getClassesInSignature()) {
-      ids.add(getShortForm(i.getIRI()));
-    }
-    return ids;
-  }
+	/**
+	 * @param id
+	 * @param ont
+	 * @return true if id is in ontology
+	 */
+	private boolean isIn(String id, String ont) {
+		// TODO - use curie util
+		return id.startsWith(ont + ":") || id.contains("/" + ont + "_");
+	}
 
-  public Set<String> getClassIdsByOntology(String ont) {
-      return getClassIdsInSignature().stream().filter(x -> isIn(x, ont)).collect(Collectors.toSet());
-  }
+	public int getNumClassNodes() {
+		return classNodeArray.length;
+	}
 
-  /**
-   * @param id
-   * @param ont
-   * @return true if id is in ontology
-   */
-  public boolean isIn(String id, String ont) {
-      // TODO - use curie util
-      return id.startsWith(ont+":") || id.contains("/"+ont+"_");
-  }
+	/**
+	 * @return set of all individual identifiers
+	 */
+	protected Set<OWLNamedIndividual> getIndividualsInSignature() {
+		return individualsInSignature;
+	}
 
-  public int getNumClassNodes() {
-    return classNodeArray.length;
-  }
+	/**
+	 * @return ids
+	 */
+	public Set<String> getIndividualIdsInSignature() {
+		Set<String> ids = new HashSet<>();
+		for (OWLNamedIndividual i : getIndividualsInSignature()) {
+			ids.add(getShortForm(i.getIRI()));
+		}
+		return ids;
+	}
 
+	/**
+	 * @return OWLAPI representation of the ontology
+	 */
+	protected OWLOntology getOwlOntology() {
+		return owlOntology;
+	}
 
+	// Assumption: data ontology includes ObjectPropertyAssertions
+	// TODO: make flexible
+	// TODO: extract associations
+	private void translateFromDataOntology() {
+		// TODO: allow other axiom types
+		for (OWLObjectPropertyAssertionAxiom opa : owlDataOntology.getAxioms(AxiomType.OBJECT_PROPERTY_ASSERTION)) {
+			OWLIndividual obj = opa.getObject();
+			if (obj instanceof OWLNamedIndividual) {
+				OWLClass type = getOWLDataFactory().getOWLClass(((OWLNamedIndividual) obj).getIRI());
+				OWLClassAssertionAxiom ca = getOWLDataFactory().getOWLClassAssertionAxiom(type, opa.getSubject());
+				owlOntology.getOWLOntologyManager().addAxiom(owlOntology, ca);
+			}
+		}
+	}
 
-  /**
-   * @return set of all individual identifiers
-   */
-  protected Set<OWLNamedIndividual> getIndividualsInSignature() {
-    return individualsInSignature;
-  }
+	// Each OWLClass and OWLIndividual is mapped to an Integer index
+	private void createMap() {
+		LOG.info("Creating mapping from ontology objects to integers");
+		classNodes = new HashSet<>();
+		individualNodes = new HashSet<>();
+		Set<OWLClass> classesInSignature;
+		classesInSignature = owlOntology.getClassesInSignature(true);
+		LOG.info("|classes|=" + classesInSignature.size());
+		classesInSignature.add(getOWLThing());
+		classesInSignature.remove(getOWLNothing());
+		individualsInSignature = owlOntology.getIndividualsInSignature(true);
+		LOG.info("|individuals|=" + individualsInSignature.size());
+		classToNodeMap = new HashMap<>();
+		individualToNodeMap = new HashMap<>();
+		classNodeToIntegerMap = new HashMap<>();
+		individualNodeToIntegerMap = new HashMap<>();
+		propertyValueMapMap = new HashMap<>();
+		final HashMap<Node<OWLClass>, Integer> classNodeToFrequencyMap = new HashMap<>();
+		final HashMap<Node<OWLClass>, Double> classNodeToFreqDepthMap = new HashMap<>();
+		for (OWLClass c : classesInSignature) {
+			if (owlReasoner.getInstances(c, false).isEmpty()) {
+				// TODO: deal with subclasses
+				// LOG.info("Skipping non-instantiated class: "+c);
+				// continue;
+			}
+			Node<OWLClass> node = owlReasoner.getEquivalentClasses(c);
+			if (node.contains(getOWLNothing())) {
+				LOG.warn("Ignoring unsatisfiable class: " + c);
+				continue;
+			}
+			classNodes.add(node);
+			classToNodeMap.put(c, node);
+			int numAncNodes = owlReasoner.getSuperClasses(c, false).getNodes().size();
+			int freq = owlReasoner.getInstances(c, false).getNodes().size();
+			classNodeToFrequencyMap.put(node, freq);
 
-  /**
-   * @return ids
-   */
-  public Set<String> getIndividualIdsInSignature() {
-    Set<String> ids = new HashSet<String>();
-    for (OWLNamedIndividual i : getIndividualsInSignature()) {
-      ids.add(getShortForm(i.getIRI()));
-    }
-    return ids;
-  }
+			// freq depth is inversely correlated informativeness;
+			// frequency is primary measure (high freq = low informativeness);
+			// if frequency is tied, then tie is broken by number of ancestors
+			// (high ancestors = high informativeness)
+			// note that if frequency is not tied, then depth/ancestors should make
+            // no overall difference - we ensure this by taking the proportion of
+            // ancestor nodes divided by number of classes (there are always equal
+			// or more classes than nodes)
+			double freqDepth = freq + 1 - (numAncNodes / (double) classesInSignature.size());
+			// LOG.info("freqDepth = "+freq+" "+freqDepth);
+			classNodeToFreqDepthMap.put(node, freqDepth);
+		}
 
+		for (OWLNamedIndividual i : individualsInSignature) {
+			Node<OWLNamedIndividual> node = owlReasoner.getSameIndividuals(i);
+			individualNodes.add(node);
+			individualToNodeMap.put(i, node);
+			setPropertyValues(owlOntology, i);
+			if (owlDataOntology != null)
+				setPropertyValues(owlDataOntology, i);
+		}
 
+		// Order class nodes such that LOW frequencies (HIGH Information Content)
+		// nodes are have LOWER indices
+		// TODO: use depth as a tie breaker
+		List<Node<OWLClass>> classNodesSorted = new ArrayList<>(classNodes);
+		classNodesSorted.sort((n1, n2) -> {
+			double f1 = classNodeToFreqDepthMap.get(n1);
+			double f2 = classNodeToFreqDepthMap.get(n2);
+			if (f1 < f2)
+				return -1;
+			if (f1 > f2)
+				return 1;
+			return 0;
+		});
+		int numClassNodes = classNodesSorted.size();
+		classNodeArray = classNodesSorted.toArray(new Node[numClassNodes]);
+		individualCountPerClassArray = new int[numClassNodes];
+		for (int i = 0; i < numClassNodes; i++) {
+			classNodeToIntegerMap.put(classNodeArray[i], i);
+			// LOG.info(classNodeArray[i] + " ix="+i + "
+			// FREQ="+classNodeToFrequencyMap.get(classNodeArray[i]));
+			// LOG.info(classNodeArray[i] + " ix="+i + "
+			// IX_REV="+classNodeToIntegerMap.get(classNodeArray[i]));
+			individualCountPerClassArray[i] = classNodeToFrequencyMap.get(classNodeArray[i]);
+		}
+		individualNodeArray = individualNodes.toArray(new Node[individualNodes.size()]);
+		for (int i = 0; i < individualNodes.size(); i++) {
+			individualNodeToIntegerMap.put(individualNodeArray[i], i);
+		}
 
-  /**
-   * @return OWLAPI representation of the ontology
-   */
-  protected OWLOntology getOwlOntology() {
-    return owlOntology;
-  }
+	}
 
-  // Assumption: data ontology includes ObjectPropertyAssertions
-  // TODO: make flexible
-  // TODO: extract associations
-  private void translateFromDataOntology() {
-    // TODO: allow other axiom types
-    for (OWLObjectPropertyAssertionAxiom opa : owlDataOntology
-        .getAxioms(AxiomType.OBJECT_PROPERTY_ASSERTION)) {
-      OWLIndividual obj = opa.getObject();
-      if (obj instanceof OWLNamedIndividual) {
-        OWLClass type = getOWLDataFactory().getOWLClass(((OWLNamedIndividual) obj).getIRI());
-        OWLClassAssertionAxiom ca =
-            getOWLDataFactory().getOWLClassAssertionAxiom(type, opa.getSubject());
-        owlOntology.getOWLOntologyManager().addAxiom(owlOntology, ca);
-      }
-    }
-  }
+	private void setPropertyValues(OWLOntology ont, OWLNamedIndividual i) {
+		Preconditions.checkNotNull(i);
+		Map<String, Set<Object>> pvm = new HashMap<>();
+		String id = getShortForm(i.getIRI());
+		propertyValueMapMap.put(id, pvm);
+		for (OWLIndividualAxiom ax : ont.getAxioms(i)) {
+			if (ax instanceof OWLPropertyAssertionAxiom) {
+				OWLPropertyAssertionAxiom paa = (OWLPropertyAssertionAxiom) ax;
+				OWLPropertyExpression p = paa.getProperty();
+				if (p instanceof OWLObjectProperty || p instanceof OWLDataProperty) {
+					String pid;
+					if (p instanceof OWLObjectProperty)
+						pid = getShortForm(((OWLObjectProperty) p).getIRI());
+					else
+						pid = getShortForm(((OWLDataProperty) p).getIRI());
+					OWLPropertyAssertionObject obj = paa.getObject();
+					if (obj instanceof OWLLiteral) {
+						addPropertyValue(pvm, pid, ((OWLLiteral) obj).getLiteral());
+					} else if (obj instanceof OWLNamedIndividual) {
+						addPropertyValue(pvm, pid, getShortForm(((OWLNamedIndividual) obj).getIRI()));
 
+					}
 
-  // Each OWLClass and OWLIndividual is mapped to an Integer index
-  private void createMap() {
-    LOG.info("Creating mapping from ontology objects to integers");
-    classNodes = new HashSet<Node<OWLClass>>();
-    individualNodes = new HashSet<Node<OWLNamedIndividual>>();
-    Set<OWLClass> classesInSignature;
-    classesInSignature = owlOntology.getClassesInSignature(true);
-    LOG.info("|classes|=" + classesInSignature.size());
-    classesInSignature.add(getOWLThing());
-    classesInSignature.remove(getOWLNothing());
-    individualsInSignature = owlOntology.getIndividualsInSignature(true);
-    LOG.info("|individuals|=" + individualsInSignature.size());
-    classToNodeMap = new HashMap<OWLClass, Node<OWLClass>>();
-    individualToNodeMap = new HashMap<OWLNamedIndividual, Node<OWLNamedIndividual>>();
-    classNodeToIntegerMap = new HashMap<Node<OWLClass>, Integer>();
-    individualNodeToIntegerMap = new HashMap<Node<OWLNamedIndividual>, Integer>();
-    propertyValueMapMap = new HashMap<String, Map<String, Set<Object>>>();
-    final HashMap<Node<OWLClass>, Integer> classNodeToFrequencyMap =
-        new HashMap<Node<OWLClass>, Integer>();
-    final HashMap<Node<OWLClass>, Double> classNodeToFreqDepthMap =
-        new HashMap<Node<OWLClass>, Double>();
-    for (OWLClass c : classesInSignature) {
-      if (owlReasoner.getInstances(c, false).isEmpty()) {
-        // TODO: deal with subclasses
-        // LOG.info("Skipping non-instantiated class: "+c);
-        // continue;
-      }
-      Node<OWLClass> node = owlReasoner.getEquivalentClasses(c);
-      if (node.contains(getOWLNothing())) {
-        LOG.warn("Ignoring unsatisfiable class: " + c);
-        continue;
-      }
-      classNodes.add(node);
-      classToNodeMap.put(c, node);
-      int numAncNodes = owlReasoner.getSuperClasses(c, false).getNodes().size();
-      int freq = owlReasoner.getInstances(c, false).getNodes().size();
-      classNodeToFrequencyMap.put(node, freq);
+				} else if (false) {
+					String pid = getShortForm(((OWLDataProperty) p).getIRI());
+					OWLLiteral obj = ((OWLDataPropertyAssertionAxiom) paa).getObject();
+					if (obj instanceof OWLLiteral) {
+						addPropertyValue(pvm, pid, ((OWLLiteral) obj).getLiteral());
+					} else if (obj instanceof OWLNamedIndividual) {
+						addPropertyValue(pvm, pid, getShortForm(((OWLNamedIndividual) obj).getIRI()));
 
-      // freq depth is inversely correlated informativeness;
-      // frequency is primary measure (high freq = low informativeness);
-      // if frequency is tied, then tie is broken by number of ancestors
-      // (high ancestors = high informativeness)
-      // note that if frequency is not tied, then depth/ancestors should make
-      // no overall difference - we ensure this by taking the proportion of
-      // ancestor nodes divided by number of classes (there are always equal
-      // or more classes than nodes)
-      double freqDepth = freq + 1 - (numAncNodes / (double) classesInSignature.size());
-      // LOG.info("freqDepth = "+freq+" "+freqDepth);
-      classNodeToFreqDepthMap.put(node, freqDepth);
-    }
+					}
 
-    for (OWLNamedIndividual i : individualsInSignature) {
-      Node<OWLNamedIndividual> node = owlReasoner.getSameIndividuals(i);
-      individualNodes.add(node);
-      individualToNodeMap.put(i, node);
-      setPropertyValues(owlOntology, i);
-      if (owlDataOntology != null)
-        setPropertyValues(owlDataOntology, i);
-    }
+				}
+			}
+		}
 
-    // Order class nodes such that LOW frequencies (HIGH Information Content)
-    // nodes are have LOWER indices
-    // TODO: use depth as a tie breaker
-    List<Node<OWLClass>> classNodesSorted = new ArrayList<Node<OWLClass>>(classNodes);
-    Collections.sort(classNodesSorted, new Comparator<Node<OWLClass>>() {
-      public int compare(Node<OWLClass> n1, Node<OWLClass> n2) {
-        double f1 = classNodeToFreqDepthMap.get(n1);
-        double f2 = classNodeToFreqDepthMap.get(n2);
-        if (f1 < f2)
-          return -1;
-        if (f1 > f2)
-          return 1;
-        return 0;
-      }
-    });
-    int numClassNodes = classNodesSorted.size();
-    classNodeArray = classNodesSorted.toArray(new Node[numClassNodes]);
-    individualCountPerClassArray = new int[numClassNodes];
-    for (int i = 0; i < numClassNodes; i++) {
-      classNodeToIntegerMap.put(classNodeArray[i], i);
-      // LOG.info(classNodeArray[i] + " ix="+i + "
-      // FREQ="+classNodeToFrequencyMap.get(classNodeArray[i]));
-      // LOG.info(classNodeArray[i] + " ix="+i + "
-      // IX_REV="+classNodeToIntegerMap.get(classNodeArray[i]));
-      individualCountPerClassArray[i] = classNodeToFrequencyMap.get(classNodeArray[i]);
-    }
-    individualNodeArray = individualNodes.toArray(new Node[individualNodes.size()]);
-    for (int i = 0; i < individualNodes.size(); i++) {
-      individualNodeToIntegerMap.put(individualNodeArray[i], i);
-    }
+	}
 
-  }
+	private void addPropertyValue(Map<String, Set<Object>> pvm, String pid, String v) {
+		// LOG.debug("PV="+pid+"="+v);
+		if (!pvm.containsKey(pid))
+			pvm.put(pid, new HashSet<>());
+		pvm.get(pid).add(v);
+	}
 
+	private void addOpposingClassPair(OWLClass c, OWLClassExpression dc) {
+		addOpposingClassPairAsym(c, dc);
+		if (!dc.isAnonymous())
+			addOpposingClassPairAsym(dc.asOWLClass(), c);
+	}
 
-  private void setPropertyValues(OWLOntology ont, OWLNamedIndividual i) {
-    Preconditions.checkNotNull(i);
-    Map<String, Set<Object>> pvm = new HashMap<String, Set<Object>>();
-    String id = getShortForm(i.getIRI());
-    propertyValueMapMap.put(id, pvm);
-    for (OWLIndividualAxiom ax : ont.getAxioms(i)) {
-      if (ax instanceof OWLPropertyAssertionAxiom) {
-        OWLPropertyAssertionAxiom paa = (OWLPropertyAssertionAxiom) ax;
-        OWLPropertyExpression p = paa.getProperty();
-        if (p instanceof OWLObjectProperty || p instanceof OWLDataProperty) {
-          String pid;
-          if (p instanceof OWLObjectProperty)
-            pid = getShortForm(((OWLObjectProperty) p).getIRI());
-          else
-            pid = getShortForm(((OWLDataProperty) p).getIRI());
-          OWLPropertyAssertionObject obj = paa.getObject();
-          if (obj instanceof OWLLiteral) {
-            addPropertyValue(pvm, pid, ((OWLLiteral) obj).getLiteral());
-          } else if (obj instanceof OWLNamedIndividual) {
-            addPropertyValue(pvm, pid, getShortForm(((OWLNamedIndividual) obj).getIRI()));
+	private void addOpposingClassPairAsym(OWLClass c, OWLClassExpression d) {
+		if (!opposingClassMap.containsKey(c))
+			opposingClassMap.put(c, new HashSet<>());
+		opposingClassMap.get(c).add(d);
+	}
 
-          }
+	private void storeInferences() {
 
-        } else if (false) {
-          String pid = getShortForm(((OWLDataProperty) p).getIRI());
-          OWLLiteral obj = ((OWLDataPropertyAssertionAxiom) paa).getObject();
-          if (obj instanceof OWLLiteral) {
-            addPropertyValue(pvm, pid, ((OWLLiteral) obj).getLiteral());
-          } else if (obj instanceof OWLNamedIndividual) {
-            addPropertyValue(pvm, pid, getShortForm(((OWLNamedIndividual) obj).getIRI()));
+		// Note: if there are any nodes containing >1 class or individual, then
+		// the store method is called redundantly. This is unlikely to affect performance,
+		// and the semantics are unchanged
+		for (OWLClass c : getClassesInSignature()) {
+			int clsIndex = getIndex(c);
+			// LOG.info("Storing inferences for "+c+" --> " + clsIndex);
+			Set<Integer> sups = getIntegersForClassSet(owlReasoner.getSuperClasses(c, false));
+			sups.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(c)));
 
-          }
+			Set<Integer> subs = getIntegersForClassSet(owlReasoner.getSubClasses(c, false));
+			subs.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(c)));
 
-        }
-      }
-    }
+			ontoEWAHStore.setDirectSuperClasses(clsIndex, getIntegersForClassSet(owlReasoner.getSuperClasses(c, true)));
+			ontoEWAHStore.setSuperClasses(clsIndex, sups);
+			ontoEWAHStore.setDirectSubClasses(clsIndex, getIntegersForClassSet(owlReasoner.getSubClasses(c, true)));
+			ontoEWAHStore.setSubClasses(clsIndex, subs);
 
-  }
+			// Find all disjoint pairs plus opposing pairs
+			for (OWLAnnotationAssertionAxiom aaa : owlOntology.getAnnotationAssertionAxioms(c.getIRI())) {
+				// RO_0002604 is-opposite-of. TODO - use a vocabulary object
+				if (aaa.getProperty().getIRI().toString().equals("http://purl.obolibrary.org/obo/RO_0002604")) {
+					OWLAnnotationValue v = aaa.getValue();
+					if (v instanceof IRI) {
+						IRI dciri = (IRI) v;
+						OWLClass dc = owlOntology.getOWLOntologyManager().getOWLDataFactory().getOWLClass(dciri);
+						addOpposingClassPair(c, dc);
 
+					}
+				}
+			}
 
-  private void addPropertyValue(Map<String, Set<Object>> pvm, String pid, String v) {
-    // LOG.debug("PV="+pid+"="+v);
-    if (!pvm.containsKey(pid))
-      pvm.put(pid, new HashSet<Object>());
-    pvm.get(pid).add(v);
-  }
+			for (OWLDisjointClassesAxiom dca : owlOntology.getDisjointClassesAxioms(c)) {
+				for (OWLClassExpression dc : dca.getClassExpressionsMinus(c)) {
+					addOpposingClassPair(c, dc);
+				}
+			}
 
-  private void addOpposingClassPair(OWLClass c, OWLClassExpression dc) {
-    addOpposingClassPairAsym(c, dc);
-    if (!dc.isAnonymous())
-      addOpposingClassPairAsym(dc.asOWLClass(), c);
-  }
+			// direct individuals are those asserted to be of type c or anything equivalent to c
+			Set<Integer> individualInts = new HashSet<>();
+			for (OWLClass ec : owlReasoner.getEquivalentClasses(c).getEntities()) {
+				for (OWLClassAssertionAxiom ax : owlOntology.getClassAssertionAxioms(ec)) {
+					if (ax.getIndividual().isNamed()) {
+						individualInts.add(getIndex(ax.getIndividual().asOWLNamedIndividual()));
+					}
+				}
+			}
+			ontoEWAHStore.setDirectIndividuals(clsIndex, individualInts);
 
-  private void addOpposingClassPairAsym(OWLClass c, OWLClassExpression d) {
-    if (!opposingClassMap.containsKey(c))
-      opposingClassMap.put(c, new HashSet<OWLClassExpression>());
-    opposingClassMap.get(c).add(d);
-  }
+		}
 
-  private void storeInferences() {
+        // populate frequency-awareness map
+        individualToWeightedDirectTypeMap = new HashMap<>();
+		for (OWLNamedIndividual i : individualsInSignature) {
+			int individualIndex = getIndex(i);
+			// LOG.info("String inferences for "+i+" --> " +individualIndex);
+			ontoEWAHStore.setDirectTypes(individualIndex, getIntegersForClassSet(owlReasoner.getTypes(i, true)));
+			ontoEWAHStore.setTypes(individualIndex, getIntegersForClassSet(owlReasoner.getTypes(i, false)));
 
-
-    // Note: if there are any nodes containing >1 class or individual, then
-    // the store method is called redundantly. This is unlikely to affect performance,
-    // and the semantics are unchanged
-    for (OWLClass c : getClassesInSignature()) {
-      int clsIndex = getIndex(c);
-      // LOG.info("Storing inferences for "+c+" --> " + clsIndex);
-      Set<Integer> sups = getIntegersForClassSet(owlReasoner.getSuperClasses(c, false));
-      sups.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(c)));
-
-      Set<Integer> subs = getIntegersForClassSet(owlReasoner.getSubClasses(c, false));
-      subs.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(c)));
-
-      ontoEWAHStore.setDirectSuperClasses(clsIndex,
-          getIntegersForClassSet(owlReasoner.getSuperClasses(c, true)));
-      ontoEWAHStore.setSuperClasses(clsIndex, sups);
-      ontoEWAHStore.setDirectSubClasses(clsIndex,
-          getIntegersForClassSet(owlReasoner.getSubClasses(c, true)));
-      ontoEWAHStore.setSubClasses(clsIndex, subs);
-
-      // Find all disjoint pairs plus opposing pairs
-      for (OWLAnnotationAssertionAxiom aaa : owlOntology.getAnnotationAssertionAxioms(c.getIRI())) {
-        // RO_0002604 is-opposite-of. TODO - use a vocabulary object
-        if (aaa.getProperty().getIRI().toString()
-            .equals("http://purl.obolibrary.org/obo/RO_0002604")) {
-          OWLAnnotationValue v = aaa.getValue();
-          if (v instanceof IRI) {
-            IRI dciri = (IRI) v;
-            OWLClass dc =
-                owlOntology.getOWLOntologyManager().getOWLDataFactory().getOWLClass(dciri);
-            addOpposingClassPair(c, dc);
-
-          }
-        }
-      }
-
-      for (OWLDisjointClassesAxiom dca : owlOntology.getDisjointClassesAxioms(c)) {
-        for (OWLClassExpression dc : dca.getClassExpressionsMinus(c)) {
-          addOpposingClassPair(c, dc);
-        }
-      }
-
-
-      // direct individuals are those asserted to be of type c or anything equivalent to c
-      Set<Integer> individualInts = new HashSet<Integer>();
-      for (OWLClass ec : owlReasoner.getEquivalentClasses(c).getEntities()) {
-        for (OWLClassAssertionAxiom ax : owlOntology.getClassAssertionAxioms(ec)) {
-          if (ax.getIndividual().isNamed()) {
-            individualInts.add(getIndex(ax.getIndividual().asOWLNamedIndividual()));
-          }
-        }
-      }
-      ontoEWAHStore.setDirectIndividuals(clsIndex, individualInts);
-
-    }
-    
-    // populate frequency-awareness map
-    individualToWeightedDirectTypeMap = new HashMap<>();
-    for (OWLNamedIndividual i : individualsInSignature) {
-      int individualIndex = getIndex(i);
-      // LOG.info("String inferences for "+i+" --> " +individualIndex);
-      ontoEWAHStore.setDirectTypes(individualIndex,
-          getIntegersForClassSet(owlReasoner.getTypes(i, true)));
-      ontoEWAHStore.setTypes(individualIndex,
-          getIntegersForClassSet(owlReasoner.getTypes(i, false)));
-      
       // TODO - ensure robust for equivalent individuals
       Map<Integer, Integer> wmap = new HashMap<>();
       individualToWeightedDirectTypeMap.put(individualIndex, wmap);
       for (OWLClassAssertionAxiom caax : owlOntology.getClassAssertionAxioms(i)) {
           int cix;
-          
+
           // only associations to named classes
           if (caax.getClassExpression().isAnonymous()) {
               continue;
           }
           cix = getIndex(caax.getClassExpression().asOWLClass());
-          
+
           // we use reification to store probability
           for (OWLAnnotation ann : caax.getAnnotations()) {
               OWLAnnotationProperty prop = ann.getProperty();
@@ -549,7 +529,7 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
                       if (prop.getIRI().toString().contains("frequency")) {
                           wmap.put(cix, lv.parseInteger());
                       }
-                      
+
                   }
               }
           }
@@ -558,442 +538,432 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
       // Treat ClassAssertion( ComplementOf(c) i) as a negative assertion
       Set<Integer> ncs = new HashSet<Integer>();
       Set<Integer> ncsDirect = new HashSet<Integer>();
-      for (OWLClassAssertionAxiom cx : owlOntology.getClassAssertionAxioms(i)) {
-        // TODO: investigate efficiency - number of items set may be high
-        if (cx.getClassExpression() instanceof OWLObjectComplementOf) {
-          OWLObjectComplementOf nx = (OWLObjectComplementOf) (cx.getClassExpression());
-          OWLClassExpression nc = nx.getOperand();
-          ncs.addAll(getIntegersForClassSet(owlReasoner.getSubClasses(nc, false)));
-          ncs.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(nc)));
-          ncsDirect.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(nc)));
-        }
-      }
+			for (OWLClassAssertionAxiom cx : owlOntology.getClassAssertionAxioms(i)) {
+				// TODO: investigate efficiency - number of items set may be high
+				if (cx.getClassExpression() instanceof OWLObjectComplementOf) {
+					OWLObjectComplementOf nx = (OWLObjectComplementOf) (cx.getClassExpression());
+					OWLClassExpression nc = nx.getOperand();
+					ncs.addAll(getIntegersForClassSet(owlReasoner.getSubClasses(nc, false)));
+					ncs.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(nc)));
+					ncsDirect.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(nc)));
+				}
+			}
 
-      // Populate negative assertions from DisjointClasses axioms
-      for (OWLClass c : owlReasoner.getTypes(i, false).getFlattened()) {
-        LOG.debug("TESTING FOR DCs: " + c);
-        if (opposingClassMap.containsKey(c)) {
-          for (OWLClassExpression dc : opposingClassMap.get(c)) {
-            LOG.info(i + " Type: " + c + " DisjointWith: " + dc);
-            ncs.addAll(getIntegersForClassSet(owlReasoner.getSubClasses(dc, false)));
-            ncs.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(dc)));
-            ncsDirect.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(dc)));
-          }
-        }
-        /*
-         * for (OWLDisjointClassesAxiom dca : owlOntology.getDisjointClassesAxioms(c)) { for
-         * (OWLClassExpression dc : dca.getClassExpressionsMinus(c)) {
-         * LOG.info(i+" Type: "+c+" DisjointWith: "+dc);
-         * ncs.addAll(getIntegersForClassSet(owlReasoner.getSubClasses(dc, false)));
-         * ncs.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(dc)));
-         * ncsDirect.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(dc))); } } for
-         * (OWLAnnotationAssertionAxiom aaa : owlOntology.getAnnotationAssertionAxioms(c.getIRI()))
-         * { // RO_0002604 is-opposite-of. TODO - use a vocabulary object if
-         * (aaa.getProperty().getIRI().toString().equals("http://purl.obolibrary.org/obo/RO_0002604"
-         * )) { OWLAnnotationValue v = aaa.getValue(); if (v instanceof IRI) { IRI dciri = (IRI)v;
-         * OWLClass dc = owlOntology.getOWLOntologyManager().getOWLDataFactory().getOWLClass(dciri);
-         * ncs.addAll(getIntegersForClassSet(owlReasoner.getSubClasses(dc, false)));
-         * ncs.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(dc)));
-         * ncsDirect.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(dc)));
-         * 
-         * } } }
-         */
-      }
+			// Populate negative assertions from DisjointClasses axioms
+			for (OWLClass c : owlReasoner.getTypes(i, false).getFlattened()) {
+				LOG.debug("TESTING FOR DCs: " + c);
+				if (opposingClassMap.containsKey(c)) {
+					for (OWLClassExpression dc : opposingClassMap.get(c)) {
+						LOG.info(i + " Type: " + c + " DisjointWith: " + dc);
+						ncs.addAll(getIntegersForClassSet(owlReasoner.getSubClasses(dc, false)));
+						ncs.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(dc)));
+						ncsDirect.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(dc)));
+					}
+				}
+				/*
+				 * for (OWLDisjointClassesAxiom dca : owlOntology.getDisjointClassesAxioms(c)) {
+				 * for (OWLClassExpression dc : dca.getClassExpressionsMinus(c)) {
+				 * LOG.info(i+" Type: "+c+" DisjointWith: "+dc);
+				 * ncs.addAll(getIntegersForClassSet(owlReasoner.getSubClasses(dc, false)));
+				 * ncs.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(dc)));
+				 * ncsDirect.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(dc))); } }
+				 * for (OWLAnnotationAssertionAxiom aaa : owlOntology.getAnnotationAssertionAxioms(c.getIRI())){
+				 * // RO_0002604 is-opposite-of. TODO - use a vocabulary object if
+				 * (aaa.getProperty().getIRI().toString().equals("http://purl.obolibrary.org/obo/RO_0002604" )) {
+				 * OWLAnnotationValue v = aaa.getValue(); if (v instanceof IRI){
+				 * IRI dciri = (IRI)v; OWLClass dc = owlOntology.getOWLOntologyManager().getOWLDataFactory(). getOWLClass(dciri);
+				 * ncs.addAll(getIntegersForClassSet(owlReasoner.getSubClasses(dc, false)));
+				 * ncs.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(dc)));
+				 * ncsDirect.add(getIndexForClassNode(owlReasoner.getEquivalentClasses(dc)));
+				 *
+				 * } } }
+				 */
+			}
 
-      ontoEWAHStore.setNegatedTypes(individualIndex, ncs); // TODO - determine if storing all
-                                                           // inferred negated types is too
-                                                           // inefficient
-      ontoEWAHStore.setDirectNegatedTypes(individualIndex, ncsDirect);
-    }
+			ontoEWAHStore.setNegatedTypes(individualIndex, ncs); // TODO - determine if storing all
+																	// inferred negated types is too
+																	// inefficient
+			ontoEWAHStore.setDirectNegatedTypes(individualIndex, ncsDirect);
+		}
 
-  }
+	}
 
-  // TODO
-  private void storeIndividualProperties() {
-    for (OWLNamedIndividual i : individualsInSignature) {
-      for (OWLIndividualAxiom ax : owlOntology.getAxioms(i)) {
-        if (ax instanceof OWLObjectPropertyAssertionAxiom) {
-          OWLObjectPropertyExpression p = ((OWLObjectPropertyAssertionAxiom) ax).getProperty();
-        }
-      }
-    }
-  }
+	// TODO
+	private void storeIndividualProperties() {
+		for (OWLNamedIndividual i : individualsInSignature) {
+			for (OWLIndividualAxiom ax : owlOntology.getAxioms(i)) {
+				if (ax instanceof OWLObjectPropertyAssertionAxiom) {
+					OWLObjectPropertyExpression p = ((OWLObjectPropertyAssertionAxiom) ax).getProperty();
+				}
+			}
+		}
+	}
 
-  // TODO - complete this
-  // TODO - separate this out as it is not an OWLAPI model. Maybe sparql is overkill here?
-  // use sparql to query the memory model
-  private void storeIndividualToClassFrequencies() {
-    String sparql = "";
-    Query query = QueryFactory.create(sparql);
-    Model model = null;
-    QueryExecution qexec = QueryExecutionFactory.create(query, model);
-    ResultSet results = qexec.execSelect();
-    for (; results.hasNext();) {
-      QuerySolution soln = results.nextSolution();
-      RDFNode x = soln.get("varName"); // Get a result variable by name.
-      Resource r = soln.getResource("VarR"); // Get a result variable - must be a resource
-      Literal l = soln.getLiteral("VarL"); // Get a result variable - must be a literal
-    }
-  }
+	// TODO - complete this
+	// TODO - separate this out as it is not an OWLAPI model. Maybe sparql is overkill here?
+	// use sparql to query the memory model
+	private void storeIndividualToClassFrequencies() {
+		String sparql = "";
+		Query query = QueryFactory.create(sparql);
+		Model model = null;
+		QueryExecution qexec = QueryExecutionFactory.create(query, model);
+		ResultSet results = qexec.execSelect();
+		for (; results.hasNext();) {
+			QuerySolution soln = results.nextSolution();
+			RDFNode x = soln.get("varName"); // Get a result variable by name.
+			Resource r = soln.getResource("VarR"); // Get a result variable - must be a resource
+			Literal l = soln.getLiteral("VarL"); // Get a result variable - must be a literal
+		}
+	}
 
+	private Set<Integer> getIntegersForClassSet(NodeSet<OWLClass> nodeset) {
+		Set<Integer> bits = new HashSet<>();
+		for (Node<OWLClass> n : nodeset.getNodes()) {
+			if (n.contains(getOWLNothing()))
+				continue;
+			bits.add(getIndexForClassNode(n));
+		}
+		return bits;
+	}
 
+	private Set<Integer> getIntegersForIndividualSet(NodeSet<OWLNamedIndividual> nodeset) {
+		Set<Integer> bits = new HashSet<>();
+		for (Node<OWLNamedIndividual> n : nodeset.getNodes()) {
+			bits.add(getIndexForIndividualNode(n));
+		}
+		return bits;
+	}
 
-  private Set<Integer> getIntegersForClassSet(NodeSet<OWLClass> nodeset) {
-    Set<Integer> bits = new HashSet<Integer>();
-    for (Node<OWLClass> n : nodeset.getNodes()) {
-      if (n.contains(getOWLNothing()))
-        continue;
-      bits.add(getIndexForClassNode(n));
-    }
-    return bits;
-  }
+	/**
+	 * Each class is mapped to an integer
+	 * 
+	 * Note that equivalent classes will be mapped to the same integer
+	 * 
+	 * @param c
+	 * @return integer representation of class
+	 */
+	private int getIndex(OWLClass c) {
+		return getIndexForClassNode(classToNodeMap.get(c));
+	}
 
+	/**
+	 * @param id
+	 * @return integer representation of class with id
+	 */
+	public int getClassIndex(String id) {
+		Preconditions.checkNotNull(id);
+		return getIndex(getOWLClass(id));
+	}
 
-  private Set<Integer> getIntegersForIndividualSet(NodeSet<OWLNamedIndividual> nodeset) {
-    Set<Integer> bits = new HashSet<Integer>();
-    for (Node<OWLNamedIndividual> n : nodeset.getNodes()) {
-      bits.add(getIndexForIndividualNode(n));
-    }
-    return bits;
-  }
+	/**
+	 * @param index
+	 * @return OWLClass Node that corresponds to this index
+	 */
+	public Node<OWLClass> getClassNode(int index) {
+		return classNodeArray[index];
+	}
 
-  /**
-   * Each class is mapped to an integer
-   * 
-   * Note that equivalent classes will be mapped to the same integer
-   * 
-   * @param c
-   * @return integer representation of class
-   */
-  protected int getIndex(OWLClass c) {
-    Preconditions.checkNotNull(c);
-    return getIndexForClassNode(classToNodeMap.get(c));
-  }
+	/**
+	 * @param index
+	 * @return OWLClass Node that corresponds to this index
+	 */
+	public Node<OWLNamedIndividual> getIndividualNode(int index) {
+		return individualNodeArray[index];
+	}
 
-  /**
-   * @param id
-   * @return integer representation of class with id
-   */
-  public int getClassIndex(String id) {
-    Preconditions.checkNotNull(id);
-    return getIndex(getOWLClass(id));
-  }
+	/**
+	 * @param cix
+	 * @return bitmap
+	 */
+	public EWAHCompressedBitmap getDirectIndividualsBM(int cix) {
+		return ontoEWAHStore.getDirectIndividuals(cix);
+	}
 
-  /**
-   * @param index
-   * @return OWLClass Node that corresponds to this index
-   */
-  public Node<OWLClass> getClassNode(int index) {
-    return classNodeArray[index];
-  }
+	@Override
+	public EWAHCompressedBitmap getIndividualsBM(String classId) {
+		return getIndividualsBM(getClassIndex(classId));
+	}
 
-  /**
-   * @param index
-   * @return OWLClass Node that corresponds to this index
-   */
-  public Node<OWLNamedIndividual> getIndividualNode(int index) {
-    return individualNodeArray[index];
-  }
+	@Override
+	public EWAHCompressedBitmap getIndividualsBM(int classIndex) {
+		if (classIndex == getRootIndex()) {
+			EWAHCompressedBitmap indsBM = new EWAHCompressedBitmap();
+			indsBM.setSizeInBits(getIndividualIdsInSignature().size(), true);
+			return indsBM;
+		}
+		EWAHCompressedBitmap subsBM = getSubClasses(classIndex);
+		EWAHCompressedBitmap indsBM = null;
+		// Note this implementation iterates through all subclasses
+		// combining individuals; it is too expensive to store all inferred inds by class
+		for (int subcix : subsBM.getPositions()) {
+			EWAHCompressedBitmap bm = getDirectIndividualsBM(subcix);
+			if (indsBM == null) {
+				indsBM = bm;
+			} else {
+				indsBM = indsBM.or(bm);
+			}
+		}
+		return indsBM;
+	}
 
-  /**
-   * @param cix
-   * @return bitmap
-   */
-  public EWAHCompressedBitmap getDirectIndividualsBM(int cix) {
-    return ontoEWAHStore.getDirectIndividuals(cix);
-  }
+	/**
+	 * Note: each index can correspond to multiple classes c1...cn if this set is an equivalence set.
+	 * In this case the representative classId is returned
+	 * 
+	 * @param index
+	 * @return classId
+	 */
+	public String getClassId(int index) {
+		Node<OWLClass> n = getClassNode(index);
+		OWLClass c = n.getRepresentativeElement();
+		return getShortForm(c.getIRI());
+	}
 
-  @Override
-  public EWAHCompressedBitmap getIndividualsBM(String classId) {
-    return getIndividualsBM(getClassIndex(classId));
-  }
+	public Set<String> getClassIds(int index) {
+		Node<OWLClass> n = getClassNode(index);
+		Set<String> cids = new HashSet<>();
+		for (OWLClass c : n.getEntities()) {
+			cids.add(getShortForm(c.getIRI()));
+		}
+		return cids;
+	}
 
-  @Override
-  public EWAHCompressedBitmap getIndividualsBM(int classIndex) {
-    if (classIndex == getRootIndex()) {
-      EWAHCompressedBitmap indsBM = new EWAHCompressedBitmap();
-      indsBM.setSizeInBits(getIndividualIdsInSignature().size(), true);
-      return indsBM;
-    }
-    EWAHCompressedBitmap subsBM = getSubClasses(classIndex);
-    EWAHCompressedBitmap indsBM = null;
-    // Note this implementation iterates through all subclasses
-    // combining individuals; it is too expensive to store all inferred inds by class
-    for (int subcix : subsBM.getPositions()) {
-      EWAHCompressedBitmap bm = getDirectIndividualsBM(subcix);
-      if (indsBM == null) {
-        indsBM = bm;
-      } else {
-        indsBM = indsBM.or(bm);
-      }
-    }
-    return indsBM;
-  }
+	public Set<String> getClassIds(EWAHCompressedBitmap bm) {
+		Set<String> cids = new HashSet<>();
+		for (int x : bm) {
+			Node<OWLClass> n = getClassNode(x);
+			for (OWLClass c : n.getEntities()) {
+				cids.add(getShortForm(c.getIRI()));
+			}
+		}
+		return cids;
+	}
 
+	/**
+	 * @param id
+	 * @return integer representation of class with id
+	 */
+	public int getIndividualIndex(String id) {
+		Preconditions.checkNotNull(id);
+		return getIndex(getOWLNamedIndividual(id));
+	}
 
-  /**
-   * Note: each index can correspond to multiple classes c1...cn if this set is an equivalence set.
-   * In this case the representative classId is returned
-   * 
-   * @param index
-   * @return classId
-   */
-  public String getClassId(int index) {
-    Node<OWLClass> n = getClassNode(index);
-    OWLClass c = n.getRepresentativeElement();
-    return getShortForm(c.getIRI());
-  }
+	/**
+	 * Each set of equivalent classes (a class node) is mapped to a unique integer
+	 * 
+	 * @param n
+	 * @return integer representation of class node
+	 */
+	private Integer getIndexForClassNode(Node<OWLClass> n) {
+		Preconditions.checkNotNull(n);
+		if (!classNodeToIntegerMap.containsKey(n))
+			LOG.error("No such node: " + n);
+		return classNodeToIntegerMap.get(n);
+	}
 
-  public Set<String> getClassIds(int index) {
-    Node<OWLClass> n = getClassNode(index);
-    Set<String> cids = new HashSet<String>();
-    for (OWLClass c : n.getEntities()) {
-      cids.add(getShortForm(c.getIRI()));
-    }
-    return cids;
-  }
+	/**
+	 * Each individual is mapped to an integer
+	 * 
+	 * Note that individuals that stand in a SameAs relationship to one another will be mapped to the
+	 * same integer
+	 * 
+	 * @param i
+	 * @return integer representation of individual
+	 */
+	private int getIndex(OWLNamedIndividual i) {
+		return getIndexForIndividualNode(individualToNodeMap.get(i));
+	}
 
-  public Set<String> getClassIds(EWAHCompressedBitmap bm) {
-    Set<String> cids = new HashSet<String>();
-    for (int x : bm) {
-      Node<OWLClass> n = getClassNode(x);
-      for (OWLClass c : n.getEntities()) {
-        cids.add(getShortForm(c.getIRI()));
-      }
-    }
-    return cids;
-  }
+	/**
+	 * Each set of same individuals (an individual node) is mapped to a unique integer
+	 * 
+	 * @param n
+	 * @return integer representation of class node
+	 */
+	private int getIndexForIndividualNode(Node<OWLNamedIndividual> n) {
+		return individualNodeToIntegerMap.get(n);
+	}
 
+	/**
+	 * @param c
+	 * @return Bitmap representation of set of superclasses of c (direct and indirect)
+	 */
+	protected EWAHCompressedBitmap getSuperClassesBM(OWLClass c) {
+		return ontoEWAHStore.getSuperClasses(getIndex(c));
+	}
 
-  /**
-   * @param id
-   * @return integer representation of class with id
-   */
-  public int getIndividualIndex(String id) {
-    Preconditions.checkNotNull(id);
-    return getIndex(getOWLNamedIndividual(id));
-  }
+	/**
+	 * @param c
+	 * @return Bitmap representation of set of direct superclasses of c
+	 */
+	protected EWAHCompressedBitmap getDirectSuperClassesBM(OWLClass c) {
+		return ontoEWAHStore.getDirectSuperClasses(getIndex(c));
+	}
 
-  /**
-   * Each set of equivalent classes (a class node) is mapped to a unique integer
-   * 
-   * @param n
-   * @return integer representation of class node
-   */
-  protected int getIndexForClassNode(Node<OWLClass> n) {
-    Preconditions.checkNotNull(n);
-    if (!classNodeToIntegerMap.containsKey(n))
-      LOG.error("No such node: " + n);
-    return classNodeToIntegerMap.get(n);
-  }
+	/**
+	 * @param c
+	 * @param isDirect
+	 * @return Bitmap representation of set ofsuperclasses of c
+	 */
+	protected EWAHCompressedBitmap getSuperClassesBM(OWLClass c, boolean isDirect) {
+		return ontoEWAHStore.getSuperClasses(getIndex(c), isDirect);
+	}
 
-  /**
-   * Each individual is mapped to an integer
-   * 
-   * Note that individuals that stand in a SameAs relationship to one another will be mapped to the
-   * same integer
-   * 
-   * @param i
-   * @return integer representation of individual
-   */
-  protected int getIndex(OWLNamedIndividual i) {
-    return getIndexForIndividualNode(individualToNodeMap.get(i));
-  }
-
-  /**
-   * Each set of same individuals (an individual node) is mapped to a unique integer
-   * 
-   * @param n
-   * @return integer representation of class node
-   */
-  protected int getIndexForIndividualNode(Node<OWLNamedIndividual> n) {
-    return individualNodeToIntegerMap.get(n);
-  }
-
-
-
-  /**
-   * @param c
-   * @return Bitmap representation of set of superclasses of c (direct and indirect)
-   */
-  protected EWAHCompressedBitmap getSuperClassesBM(OWLClass c) {
-    return ontoEWAHStore.getSuperClasses(getIndex(c));
-  }
-
-  /**
-   * @param c
-   * @return Bitmap representation of set of direct superclasses of c
-   */
-  protected EWAHCompressedBitmap getDirectSuperClassesBM(OWLClass c) {
-    return ontoEWAHStore.getDirectSuperClasses(getIndex(c));
-  }
-
-  /**
-   * @param c
-   * @param isDirect
-   * @return Bitmap representation of set ofsuperclasses of c
-   */
-  protected EWAHCompressedBitmap getSuperClassesBM(OWLClass c, boolean isDirect) {
-    return ontoEWAHStore.getSuperClasses(getIndex(c), isDirect);
-  }
-
-  /**
-   * @param clsSet
-   * @return union of all superClasses (direct and indirect) of any input class
-   */
-  protected EWAHCompressedBitmap getSuperClassesBMByOWLClassSet(Set<OWLClass> clsSet) {
-    Set<Integer> classIndices = new HashSet<Integer>();
-    for (OWLClass c : clsSet) {
-      classIndices.add(getIndex(c));
-    }
-    return ontoEWAHStore.getSuperClasses(classIndices);
-  }
+	/**
+	 * @param clsSet
+	 * @return union of all superClasses (direct and indirect) of any input class
+	 */
+	protected EWAHCompressedBitmap getSuperClassesBMByOWLClassSet(Set<OWLClass> clsSet) {
+		Set<Integer> classIndices = new HashSet<>();
+		for (OWLClass c : clsSet) {
+			classIndices.add(getIndex(c));
+		}
+		return ontoEWAHStore.getSuperClasses(classIndices);
+	}
 
   /* (non-Javadoc)
  * @see org.monarchinitiative.owlsim.kb.BMKnowledgeBase#getSuperClassesBM(com.googlecode.javaewah.EWAHCompressedBitmap)
  */
   public EWAHCompressedBitmap getSuperClassesBM(EWAHCompressedBitmap classesBM) {
-      return ontoEWAHStore.getSuperClasses(new HashSet<>(classesBM.getPositions()));      
+      return ontoEWAHStore.getSuperClasses(new HashSet<>(classesBM.getPositions()));
   }
 
-  public EWAHCompressedBitmap getSuperClassesBM(String cid) {
-    return ontoEWAHStore.getSuperClasses(getClassIndex(cid));
-  }
+	public EWAHCompressedBitmap getSuperClassesBM(String cid) {
+		return ontoEWAHStore.getSuperClasses(getClassIndex(cid));
+	}
 
-  public EWAHCompressedBitmap getDirectSuperClassesBM(String cid) {
-    return ontoEWAHStore.getDirectSuperClasses(getClassIndex(cid));
-  }
+	public EWAHCompressedBitmap getDirectSuperClassesBM(String cid) {
+		return ontoEWAHStore.getDirectSuperClasses(getClassIndex(cid));
+	}
 
-  public EWAHCompressedBitmap getSuperClassesBM(int classIndex) {
-    return ontoEWAHStore.getSuperClasses(classIndex);
-  }
+	public EWAHCompressedBitmap getSuperClassesBM(int classIndex) {
+		return ontoEWAHStore.getSuperClasses(classIndex);
+	}
 
-  public EWAHCompressedBitmap getClassesBM(Set<String> classIds) {
-    EWAHCompressedBitmap bm = new EWAHCompressedBitmap();
-    for (String id : classIds) {
-      bm.set(getClassIndex(id));
-    }
-    return bm;
-  }
+	public EWAHCompressedBitmap getClassesBM(Set<String> classIds) {
+		EWAHCompressedBitmap bm = new EWAHCompressedBitmap();
+		for (String id : classIds) {
+			bm.set(getClassIndex(id));
+		}
+		return bm;
+	}
 
+	public EWAHCompressedBitmap getDirectSuperClassesBM(int classIndex) {
+		return ontoEWAHStore.getDirectSuperClasses(classIndex);
+	}
 
-  public EWAHCompressedBitmap getDirectSuperClassesBM(int classIndex) {
-    return ontoEWAHStore.getDirectSuperClasses(classIndex);
-  }
+	public EWAHCompressedBitmap getSubClasses(int classIndex) {
+		return ontoEWAHStore.getSubClasses(classIndex);
+	}
 
-  public EWAHCompressedBitmap getSubClasses(int classIndex) {
-    return ontoEWAHStore.getSubClasses(classIndex);
-  }
+	public EWAHCompressedBitmap getDirectSubClassesBM(String cid) {
+		return ontoEWAHStore.getDirectSubClasses(getClassIndex(cid));
+	}
 
-  public EWAHCompressedBitmap getDirectSubClassesBM(String cid) {
-    return ontoEWAHStore.getDirectSubClasses(getClassIndex(cid));
-  }
+	public EWAHCompressedBitmap getDirectSubClassesBM(int classIndex) {
+		return ontoEWAHStore.getDirectSubClasses(classIndex);
+	}
 
-  public EWAHCompressedBitmap getDirectSubClassesBM(int classIndex) {
-    return ontoEWAHStore.getDirectSubClasses(classIndex);
-  }
+	/**
+	 * @param clsIds
+	 * @return union of all subClasses (direct and indirect) of any input class
+	 */
+	public EWAHCompressedBitmap getSubClassesBM(Set<String> clsIds) {
+		Set<Integer> classIndices = new HashSet<>();
+		for (String id : clsIds) {
+			classIndices.add(getClassIndex(id));
+		}
+		return ontoEWAHStore.getSubClasses(classIndices);
+	}
 
-  /**
-   * @param clsIds
-   * @return union of all subClasses (direct and indirect) of any input class
-   */
-  public EWAHCompressedBitmap getSubClassesBM(Set<String> clsIds) {
-    Set<Integer> classIndices = new HashSet<Integer>();
-    for (String id : clsIds) {
-      classIndices.add(getClassIndex(id));
-    }
-    return ontoEWAHStore.getSubClasses(classIndices);
-  }
+	/**
+	 * @param clsIds
+	 * @return union of all direct subClasses of all input classes
+	 */
+	public EWAHCompressedBitmap getDirectSubClassesBM(Set<String> clsIds) {
+		Set<Integer> classIndices = new HashSet<>();
+		for (String id : clsIds) {
+			classIndices.add(getClassIndex(id));
+		}
+		return ontoEWAHStore.getDirectSubClasses(classIndices);
+	}
 
-  /**
-   * @param clsIds
-   * @return union of all direct subClasses of all input classes
-   */
-  public EWAHCompressedBitmap getDirectSubClassesBM(Set<String> clsIds) {
-    Set<Integer> classIndices = new HashSet<Integer>();
-    for (String id : clsIds) {
-      classIndices.add(getClassIndex(id));
-    }
-    return ontoEWAHStore.getDirectSubClasses(classIndices);
-  }
+	/**
+	 * @param clsIds
+	 * @return union of all superClasses (direct and indirect) of any input class
+	 */
+	public EWAHCompressedBitmap getSuperClassesBM(Set<String> clsIds) {
+		Set<Integer> classIndices = new HashSet<>();
+		for (String id : clsIds) {
+			classIndices.add(getClassIndex(id));
+		}
+		return ontoEWAHStore.getSuperClasses(classIndices);
+	}
 
+    /**
+	 * @param clsIds
+	 * @return union of all direct superClasses of all input classes
+	 */
+	public EWAHCompressedBitmap getDirectSuperClassesBM(Set<String> clsIds) {
+		Set<Integer> classIndices = new HashSet<Integer>();
+		for (String id : clsIds) {
+			classIndices.add(getClassIndex(id));
+		}
+		return ontoEWAHStore.getDirectSuperClasses(classIndices);
+	}
 
-  /**
-   * @param clsIds
-   * @return union of all superClasses (direct and indirect) of any input class
-   */
-  public EWAHCompressedBitmap getSuperClassesBM(Set<String> clsIds) {
-    Set<Integer> classIndices = new HashSet<Integer>();
-    for (String id : clsIds) {
-      classIndices.add(getClassIndex(id));
-    }
-    return ontoEWAHStore.getSuperClasses(classIndices);
-  }
+	/**
+	 * @param i
+	 * @return Bitmap representation of set of (direct or indirect) types of i
+	 */
+	protected EWAHCompressedBitmap getTypesBM(OWLNamedIndividual i) {
+		return ontoEWAHStore.getTypes(getIndex(i));
+	}
 
-  /**
-   * @param clsIds
-   * @return union of all direct superClasses of all input classes
-   */
-  public EWAHCompressedBitmap getDirectSuperClassesBM(Set<String> clsIds) {
-    Set<Integer> classIndices = new HashSet<Integer>();
-    for (String id : clsIds) {
-      classIndices.add(getClassIndex(id));
-    }
-    return ontoEWAHStore.getDirectSuperClasses(classIndices);
-  }
+	/**
+	 * @param i
+	 * @return Bitmap representation of set of direct types of i
+	 */
+	protected EWAHCompressedBitmap getDirectTypesBM(OWLNamedIndividual i) {
+		return ontoEWAHStore.getDirectTypes(getIndex(i));
+	}
 
-  /**
-   * @param i
-   * @return Bitmap representation of set of (direct or indirect) types of i
-   */
-  protected EWAHCompressedBitmap getTypesBM(OWLNamedIndividual i) {
-    return ontoEWAHStore.getTypes(getIndex(i));
-  }
+	/**
+	 * @param i
+	 * @param classFilter
+	 * @return Bitmap representation of the subset of direct types of i, which
+	 *         are descendants of classFilter
+	 */
+	protected EWAHCompressedBitmap getFilteredDirectTypesBM(OWLNamedIndividual i, OWLClass c) {
+		return ontoEWAHStore.getDirectTypes(getIndex(i), this.getIndex(c));
+	}
 
-  /**
-   * @param i
-   * @return Bitmap representation of set of direct types of i
-   */
-  protected EWAHCompressedBitmap getDirectTypesBM(OWLNamedIndividual i) {
-    return ontoEWAHStore.getDirectTypes(getIndex(i));
-  }
+	/**
+	 * @param i
+	 * @param isDirect
+	 * @return Bitmap representation of set of (direct or indirect) types of i
+	 */
+	protected EWAHCompressedBitmap getTypesBM(OWLNamedIndividual i, boolean isDirect) {
+		return ontoEWAHStore.getTypes(getIndex(i), isDirect);
+	}
 
-  /**
-   * @param i
-   * @param classFilter
-   * @return Bitmap representation of the subset of direct types of i, which are descendants of
-   *         classFilter
-   */
-  protected EWAHCompressedBitmap getFilteredDirectTypesBM(OWLNamedIndividual i, OWLClass c) {
-    return ontoEWAHStore.getDirectTypes(getIndex(i), this.getIndex(c));
-  }
+	/**
+	 * @param id
+	 * @return bitmap representation of all (direct and indirect) instantiated classes
+	 */
+	public EWAHCompressedBitmap getTypesBM(String id) {
+		Preconditions.checkNotNull(id);
+		return ontoEWAHStore.getTypes(getIndividualIndex(id));
+	}
 
-  /**
-   * @param i
-   * @param isDirect
-   * @return Bitmap representation of set of (direct or indirect) types of i
-   */
-  protected EWAHCompressedBitmap getTypesBM(OWLNamedIndividual i, boolean isDirect) {
-    return ontoEWAHStore.getTypes(getIndex(i), isDirect);
-  }
+	/**
+	 * @param individualIndex
+	 * @return bitmap representation of all (direct and indirect) instantiated classes
+	 */
+	public EWAHCompressedBitmap getTypesBM(int individualIndex) {
+		return ontoEWAHStore.getTypes(individualIndex);
+	}
 
-  /**
-   * @param id
-   * @return bitmap representation of all (direct and indirect) instantiated classes
-   */
-  public EWAHCompressedBitmap getTypesBM(String id) {
-    Preconditions.checkNotNull(id);
-    return ontoEWAHStore.getTypes(getIndividualIndex(id));
-  }
-
-  /**
-   * @param individualIndex
-   * @return bitmap representation of all (direct and indirect) instantiated classes
-   */
-  public EWAHCompressedBitmap getTypesBM(int individualIndex) {
-    return ontoEWAHStore.getTypes(individualIndex);
-  }
-  
   /* (non-Javadoc)
    * @see org.monarchinitiative.owlsim.kb.BMKnowledgeBase#getDirectWeightedTypes(java.lang.String)
    */
@@ -1003,186 +973,175 @@ public class BMKnowledgeBaseOWLAPIImpl implements BMKnowledgeBase {
   }
 
 
-  /**
-   * @param id
-   * @return bitmap representation of all (direct and indirect) classes known to be NOT instantiated
-   */
-  public EWAHCompressedBitmap getNegatedTypesBM(String id) {
-    Preconditions.checkNotNull(id);
-    return ontoEWAHStore.getNegatedTypes(getIndividualIndex(id));
-  }
+	/**
+	 * @param id
+	 * @return bitmap representation of all (direct and indirect) classes known to be NOT instantiated
+	 */
+	public EWAHCompressedBitmap getNegatedTypesBM(String id) {
+		Preconditions.checkNotNull(id);
+		return ontoEWAHStore.getNegatedTypes(getIndividualIndex(id));
+	}
 
-  /**
-   * @param id
-   * @return bitmap representation of all (direct and indirect) classes known to be NOT instantiated
-   */
-  public EWAHCompressedBitmap getDirectNegatedTypesBM(String id) {
-    Preconditions.checkNotNull(id);
-    return ontoEWAHStore.getDirectNegatedTypes(getIndividualIndex(id));
-  }
+	/**
+	 * @param id
+	 * @return bitmap representation of all (direct and indirect) classes known to be NOT instantiated
+	 */
+	public EWAHCompressedBitmap getDirectNegatedTypesBM(String id) {
+		Preconditions.checkNotNull(id);
+		return ontoEWAHStore.getDirectNegatedTypes(getIndividualIndex(id));
+	}
 
+	/**
+	 * @param id
+	 * @return bitmap representation of all (direct and indirect) instantiated classes
+	 */
+	public EWAHCompressedBitmap getDirectTypesBM(String id) {
+		Preconditions.checkNotNull(id);
+		return ontoEWAHStore.getDirectTypes(getIndividualIndex(id));
+	}
 
-  /**
-   * @param id
-   * @return bitmap representation of all (direct and indirect) instantiated classes
-   */
-  public EWAHCompressedBitmap getDirectTypesBM(String id) {
-    Preconditions.checkNotNull(id);
-    return ontoEWAHStore.getDirectTypes(getIndividualIndex(id));
-  }
+	/**
+	 * @param id
+	 * @return bitmap representation of all (direct and indirect) instantiated classes that are
+	 * subclasses of classId
+	 */
+	public EWAHCompressedBitmap getFilteredDirectTypesBM(String id, String classId) {
+		Preconditions.checkNotNull(id);
+		Preconditions.checkNotNull(classId);
+		return ontoEWAHStore.getDirectTypes(getIndividualIndex(id), getClassIndex(classId));
+	}
 
-  /**
-   * @param id
-   * @return bitmap representation of all (direct and indirect) instantiated classes that are
-   *         subclasses of classId
-   */
-  public EWAHCompressedBitmap getFilteredDirectTypesBM(String id, String classId) {
-    Preconditions.checkNotNull(id);
-    Preconditions.checkNotNull(classId);
-    return ontoEWAHStore.getDirectTypes(getIndividualIndex(id), getClassIndex(classId));
-  }
+	private OWLClass getOWLThing() {
+		return getOWLDataFactory().getOWLThing();
+	}
 
+	private OWLClass getOWLNothing() {
+		return getOWLDataFactory().getOWLNothing();
+	}
 
+	private OWLDataFactory getOWLDataFactory() {
+		return owlOntology.getOWLOntologyManager().getOWLDataFactory();
+	}
 
-  private OWLClass getOWLThing() {
-    return getOWLDataFactory().getOWLThing();
-  }
+	/**
+	 * @param obj
+	 * @return CURIE-style identifier
+	 */
+	protected String getIdentifier(OWLNamedObject obj) {
+		return obj.getIRI().toString();
+	}
 
-  private OWLClass getOWLNothing() {
-    return getOWLDataFactory().getOWLNothing();
-  }
+	/**
+	 * @param id CURIE-style
+	 * @return OWLAPI Class object
+	 */
+	private OWLClass getOWLClass(String id) {
+		Preconditions.checkNotNull(id);
+		if (curieUtil.getCurieMap().isEmpty()) {
+			return getOWLClass(IRI.create(id));
+		} else {
+			return getOWLClass(IRI.create(curieUtil.getIri(id).orElse(id)));
+		}
+	}
 
-  private OWLDataFactory getOWLDataFactory() {
-    return owlOntology.getOWLOntologyManager().getOWLDataFactory();
-  }
+	/**
+	 * @param iri
+	 * @return OWLAPI Class object
+	 */
+	private OWLClass getOWLClass(IRI iri) {
+		return owlOntology.getOWLOntologyManager().getOWLDataFactory().getOWLClass(iri);
+	}
 
+	/**
+	 * @param iri
+	 * @return OWLAPI Class object
+	 */
+	private OWLNamedIndividual getOWLNamedIndividual(IRI iri) {
+		return owlOntology.getOWLOntologyManager().getOWLDataFactory().getOWLNamedIndividual(iri);
+	}
 
-  /**
-   * @param obj
-   * @return CURIE-style identifier
-   */
-  protected String getIdentifier(OWLNamedObject obj) {
-    return obj.getIRI().toString();
-  }
+	/**
+	 * @param id
+	 *            CURIE-style
+	 * @return OWLAPI Class object
+	 */
+	public OWLNamedIndividual getOWLNamedIndividual(String id) {
+		Preconditions.checkNotNull(id);
+		//TODO: check - this is redundant code simply return getOWLNamedIndividual(IRI.create(curieUtil.getIri(id).orElse(id))); will suffice
+		if (curieUtil.getCurieMap().isEmpty()) {
+			return getOWLNamedIndividual(IRI.create(id));
+		} else {
+			return getOWLNamedIndividual(IRI.create(curieUtil.getIri(id).orElse(id)));
+		}
+	}
 
-  /**
-   * @param id CURIE-style
-   * @return OWLAPI Class object
-   */
-  protected OWLClass getOWLClass(String id) {
-    Preconditions.checkNotNull(id);
-    if (curieUtil.getCurieMap().isEmpty()) {
-      return getOWLClass(IRI.create(id));
-    } else {
-      return getOWLClass(IRI.create(curieUtil.getIri(id).orElse(id)));
-    }
-  }
+	public Attribute getAttribute(String id) {
+		Preconditions.checkNotNull(id);
+		String label = labelMapper.getArbitraryLabel(id);
+		return new Attribute(id, label);
+	}
 
-  /**
-   * @param iri
-   * @return OWLAPI Class object
-   */
-  protected OWLClass getOWLClass(IRI iri) {
-    return owlOntology.getOWLOntologyManager().getOWLDataFactory().getOWLClass(iri);
-  }
+	public Entity getEntity(String id) {
+		Preconditions.checkNotNull(id);
+		String label = labelMapper.getArbitraryLabel(id);
+		return new Entity(id, label);
+	}
 
-  /**
-   * @param iri
-   * @return OWLAPI Class object
-   */
-  protected OWLNamedIndividual getOWLNamedIndividual(IRI iri) {
-    return owlOntology.getOWLOntologyManager().getOWLDataFactory().getOWLNamedIndividual(iri);
-  }
+	public int[] getIndividualCountPerClassArray() {
+		return individualCountPerClassArray;
+	}
 
-  /**
-   * @param id CURIE-style
-   * @return OWLAPI Class object
-   */
-  public OWLNamedIndividual getOWLNamedIndividual(String id) {
-    Preconditions.checkNotNull(id);
-    if (curieUtil.getCurieMap().isEmpty()) {
-      return getOWLNamedIndividual(IRI.create(id));
-    } else {
-      return getOWLNamedIndividual(IRI.create(curieUtil.getIri(id).orElse(id)));
-    }
-  }
+	@Override
+	public Map<String, Set<Object>> getPropertyValueMap(String individualId) {
+		return propertyValueMapMap.get(individualId);
+	}
 
-  public Attribute getAttribute(String id) {
-    Preconditions.checkNotNull(id);
-    String label = labelMapper.getArbitraryLabel(id);
-    return new Attribute(id, label);
-  }
+	@Override
+	public Set<Object> getPropertyValues(String individualId, String property) {
+		Map<String, Set<Object>> m = getPropertyValueMap(individualId);
+		if (m.containsKey(property))
+			return new HashSet<>(m.get(property));
+		else
+			return Collections.emptySet();
+	}
 
-  public Entity getEntity(String id) {
-    Preconditions.checkNotNull(id);
-    String label = labelMapper.getArbitraryLabel(id);
-    return new Entity(id, label);
-  }
+	public EWAHCompressedBitmap[] getStoredDirectSubClassIndex() {
+		return ontoEWAHStore.getStoredDirectSubClasses();
+	}
 
-  public int[] getIndividualCountPerClassArray() {
-    return individualCountPerClassArray;
-  }
+	@Override
+	public int getRootIndex() {
+		return getIndex(getOWLThing());
+	}
 
+	@Override
+	public String getIndividualId(int index) {
+		Node<OWLNamedIndividual> n = getIndividualNode(index);
+		OWLNamedIndividual ind = n.getRepresentativeElement();
+		return getShortForm(ind.getIRI());
+	}
 
+	@Override
+	public EWAHCompressedBitmap getFilteredTypesBM(Set<String> ids, String classId) {
 
-  @Override
-  public Map<String, Set<Object>> getPropertyValueMap(String individualId) {
-    return propertyValueMapMap.get(individualId);
-  }
+		Set<Integer> classBits = new HashSet<>();
+		for (String id : ids) {
+			classBits.add(this.getClassIndex(id));
+		}
 
-  @Override
-  public Set<Object> getPropertyValues(String individualId, String property) {
-    Map<String, Set<Object>> m = getPropertyValueMap(individualId);
-    if (m.containsKey(property))
-      return new HashSet<Object>(m.get(property));
-    else
-      return Collections.emptySet();
-  }
+		return ontoEWAHStore.getTypes(classBits, getClassIndex(classId));
 
-  public EWAHCompressedBitmap[] getStoredDirectSubClassIndex() {
-    return ontoEWAHStore.getStoredDirectSubClasses();
-  }
+	}
 
-  @Override
-  public int getRootIndex() {
-    return getIndex(getOWLThing());
-  }
+	public EWAHCompressedBitmap getFilteredDirectTypesBM(Set<String> classIds, String classId) {
 
+		Set<Integer> classBits = new HashSet<>();
+		for (String id : classIds) {
+			classBits.add(this.getClassIndex(id));
+		}
 
+		return ontoEWAHStore.getDirectTypes(classBits, getClassIndex(classId));
 
-  @Override
-  public String getIndividualId(int index) {
-    Node<OWLNamedIndividual> n = getIndividualNode(index);
-    OWLNamedIndividual ind = n.getRepresentativeElement();
-    return getShortForm(ind.getIRI());
-  }
-
-
-
-  @Override
-  public EWAHCompressedBitmap getFilteredTypesBM(Set<String> ids, String classId) {
-
-    Set<Integer> classBits = new HashSet<Integer>();
-    for (String id : ids) {
-      classBits.add(this.getClassIndex(id));
-    }
-
-    return ontoEWAHStore.getTypes(classBits, getClassIndex(classId));
-
-  }
-
-
-  public EWAHCompressedBitmap getFilteredDirectTypesBM(Set<String> classIds, String classId) {
-
-    Set<Integer> classBits = new HashSet<Integer>();
-    for (String id : classIds) {
-      classBits.add(this.getClassIndex(id));
-    }
-
-    return ontoEWAHStore.getDirectTypes(classBits, getClassIndex(classId));
-
-  }
-
-
+	}
 
 }

--- a/owlsim-core/src/test/java/org/monarchinitiative/owlsim/compute/classmatch/ClassMatcherTest.java
+++ b/owlsim-core/src/test/java/org/monarchinitiative/owlsim/compute/classmatch/ClassMatcherTest.java
@@ -1,25 +1,20 @@
 package org.monarchinitiative.owlsim.compute.classmatch;
 
-import static org.junit.Assert.*;
-
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.List;
-
 import org.apache.log4j.Logger;
 import org.junit.Test;
-import org.monarchinitiative.owlsim.compute.mica.AbstractMICAStoreTest;
-import org.monarchinitiative.owlsim.compute.mica.MICAStore;
-import org.monarchinitiative.owlsim.compute.mica.impl.MICAStoreImpl;
 import org.monarchinitiative.owlsim.compute.mica.impl.NoRootException;
-import org.monarchinitiative.owlsim.compute.stats.KBStatsCalculator;
-import org.monarchinitiative.owlsim.io.OWLLoader;
+import org.monarchinitiative.owlsim.io.OwlKnowledgeBase;
 import org.monarchinitiative.owlsim.kb.BMKnowledgeBase;
 import org.monarchinitiative.owlsim.kb.LabelMapper;
-import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
-import com.google.monitoring.runtime.instrumentation.common.com.google.common.io.Resources;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
 
 public class ClassMatcherTest {
 
@@ -28,18 +23,26 @@ public class ClassMatcherTest {
     private Logger LOG = Logger.getLogger(ClassMatcherTest.class);
 
     protected void load(String fn, String... ontfns) throws OWLOntologyCreationException, URISyntaxException, NoRootException {
-        OWLLoader loader = new OWLLoader();
-        LOG.info("Loading: "+fn);
-        loader.load(IRI.create(Resources.getResource(fn)));
-        for (String ontfn : ontfns) {
-            URL res = getClass().getResource(ontfn);
-            LOG.info("RES="+res);
-            loader.loadOntologies(res.getFile());
-        }
-        kb = loader.createKnowledgeBaseInterface();
+//        OWLLoader loader = new OWLLoader();
+//        LOG.info("Loading: "+fn);
+//        loader.load(IRI.create(Resources.getResource(fn)));
+//        for (String ontfn : ontfns) {
+//            URL res = getClass().getResource(ontfn);
+//            LOG.info("RES="+res);
+//            loader.ontologies(res.getFile());
+//        }
+//        kb = loader.createKnowledgeBaseInterface();
+        kb = OwlKnowledgeBase.loader()
+                .loadOntology(filePath(fn))
+                .loadOntologies(Arrays.stream(ontfns).map(ontfn -> filePath(ontfn)).collect(Collectors.toList()))
+                .createKnowledgeBase();
         classMatcher = new ClassMatcher(kb);
     }
-    
+
+    private String filePath(String filename) {
+        return Paths.get("src/test/resources/", filename).toString();
+    }
+
     @Test
     public void selfTest() throws OWLOntologyCreationException, URISyntaxException, NoRootException {
         load("mp-subset.ttl");

--- a/owlsim-core/src/test/java/org/monarchinitiative/owlsim/compute/kb/impl/AbstractOwlTest.java
+++ b/owlsim-core/src/test/java/org/monarchinitiative/owlsim/compute/kb/impl/AbstractOwlTest.java
@@ -1,18 +1,16 @@
 package org.monarchinitiative.owlsim.compute.kb.impl;
 
-import java.net.URISyntaxException;
-import java.util.Set;
-
+import com.googlecode.javaewah.EWAHCompressedBitmap;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
-import org.monarchinitiative.owlsim.io.OWLLoader;
+import org.monarchinitiative.owlsim.io.OwlKnowledgeBase;
 import org.monarchinitiative.owlsim.kb.BMKnowledgeBase;
 import org.monarchinitiative.owlsim.kb.NonUniqueLabelException;
-import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
-import com.google.monitoring.runtime.instrumentation.common.com.google.common.io.Resources;
-import com.googlecode.javaewah.EWAHCompressedBitmap;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.Set;
 
 /**
  * Tests a OWLAPI implementation of a KB
@@ -27,10 +25,12 @@ public class AbstractOwlTest {
 	private Logger LOG = Logger.getLogger(AbstractOwlTest.class);
 
 	protected BMKnowledgeBase kb;
+
 	protected void load(String fn) throws OWLOntologyCreationException, URISyntaxException {
-		OWLLoader loader = new OWLLoader();
-		loader.load(IRI.create(Resources.getResource(fn)));
-		kb = loader.createKnowledgeBaseInterface();
+//		OWLLoader loader = new OWLLoader();
+//		loader.load(IRI.create(Resources.getResource(fn)));
+//		kb = loader.createKnowledgeBaseInterface();
+		kb = OwlKnowledgeBase.loader().loadOntology(Paths.get("src/test/resources", fn).toString()).createKnowledgeBase();
 	}
 
 	protected void checkContains(EWAHCompressedBitmap bm,

--- a/owlsim-core/src/test/java/org/monarchinitiative/owlsim/compute/matcher/mp/AbstractProfileMatcherMPTest.java
+++ b/owlsim-core/src/test/java/org/monarchinitiative/owlsim/compute/matcher/mp/AbstractProfileMatcherMPTest.java
@@ -1,14 +1,12 @@
 package org.monarchinitiative.owlsim.compute.matcher.mp;
 
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.collect.Sets;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 import org.monarchinitiative.owlsim.compute.matcher.ProfileMatcher;
 import org.monarchinitiative.owlsim.io.JSONWriter;
-import org.monarchinitiative.owlsim.io.OWLLoader;
+import org.monarchinitiative.owlsim.io.OwlKnowledgeBase;
 import org.monarchinitiative.owlsim.kb.BMKnowledgeBase;
 import org.monarchinitiative.owlsim.model.match.Match;
 import org.monarchinitiative.owlsim.model.match.MatchSet;
@@ -16,7 +14,8 @@ import org.monarchinitiative.owlsim.model.match.ProfileQuery;
 import org.monarchinitiative.owlsim.model.match.impl.ProfileQueryImpl;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
-import com.google.common.collect.Sets;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Tests a ProfileMatcher using the sample mp-subset.ttl ontology
@@ -229,13 +228,11 @@ public abstract class AbstractProfileMatcherMPTest {
 	}
 
 	private void load(String fn) throws OWLOntologyCreationException {
-		//Injector injector = Guice.createInjector(new ConfigModule());
-		OWLLoader loader = new OWLLoader();
-		loader.load("src/test/resources/"+fn);
-		ontology = loader.createKnowledgeBaseInterface();
-		//profileMatcher = 
-		//		injector.getInstance(ProfileMatcher.class);
-		//profileMatcher = new MaximumInformationContentSimilarityProfileMatcher(ontology);
+//		OWLLoader loader = new OWLLoader();
+//		loader.load("src/test/resources/"+fn);
+//		ontology = loader.createKnowledgeBaseInterface();
+
+		ontology = OwlKnowledgeBase.loader().loadOntology("src/test/resources/" + fn).createKnowledgeBase();
 
 		profileMatcher = createProfileMatcher(ontology);
 	}

--- a/owlsim-core/src/test/java/org/monarchinitiative/owlsim/compute/matcher/perf/HomologyPhenoPerfIT.java
+++ b/owlsim-core/src/test/java/org/monarchinitiative/owlsim/compute/matcher/perf/HomologyPhenoPerfIT.java
@@ -1,27 +1,20 @@
 package org.monarchinitiative.owlsim.compute.matcher.perf;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.junit.Test;
 import org.monarchinitiative.owlsim.compute.matcher.AbstractProfileMatcherTest;
 import org.monarchinitiative.owlsim.compute.matcher.ProfileMatcher;
-import org.monarchinitiative.owlsim.compute.matcher.impl.BayesianNetworkProfileMatcher;
-import org.monarchinitiative.owlsim.compute.matcher.impl.JaccardSimilarityProfileMatcher;
-import org.monarchinitiative.owlsim.compute.matcher.impl.MaximumInformationContentSimilarityProfileMatcher;
-import org.monarchinitiative.owlsim.compute.matcher.impl.NaiveBayesFixedWeightTwoStateProfileMatcher;
-import org.monarchinitiative.owlsim.compute.matcher.impl.PhenodigmICProfileMatcher;
+import org.monarchinitiative.owlsim.compute.matcher.impl.*;
 import org.monarchinitiative.owlsim.eval.ProfileMatchEvaluator;
-import org.monarchinitiative.owlsim.io.OWLLoader;
+import org.monarchinitiative.owlsim.io.OwlKnowledgeBase;
 import org.monarchinitiative.owlsim.io.ReadMappingsUtil;
 import org.monarchinitiative.owlsim.kb.filter.Filter;
 import org.monarchinitiative.owlsim.kb.filter.TypeFilter;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+
+import java.io.IOException;
+import java.util.*;
 
 /**
  * Tests phenotype matcher by finding rank of each homolog when using that matcher
@@ -126,12 +119,19 @@ public class HomologyPhenoPerfIT extends AbstractProfileMatcherTest {
     }
 
     private void load() throws OWLOntologyCreationException, IOException {
-        OWLLoader loader = new OWLLoader();
-        loader.loadGzippdOntology(getClass().getResource("/ontologies/mammal.obo.gz").getFile());
-        loader.loadDataFromTsvGzip(getClass().getResource("/data/gene2taxon.tsv.gz").getFile());
-        loader.loadDataFromTsvGzip(getClass().getResource("/data/mouse-pheno.assocs.gz").getFile());
-        loader.loadDataFromTsvGzip(getClass().getResource("/data/human-pheno.assocs.gz").getFile());
-        kb = loader.createKnowledgeBaseInterface();
+        Map<String, String> curies = new LinkedHashMap<>();
+        curies.put("HP", "http://purl.obolibrary.org/obo/HP_");
+        curies.put("MP", "http://purl.obolibrary.org/obo/MP_");
+        curies.put("NCBITaxon", "http://purl.obolibrary.org/obo/NCBITaxon_");
+
+        kb = OwlKnowledgeBase.loader()
+                .loadCuries(curies)
+                .loadOntology("src/test/resources/ontologies/mammal.obo.gz")
+                .loadDataFromTsv(
+                        "src/test/resources/data/gene2taxon.tsv.gz",
+                        "src/test/resources/data/mouse-pheno.assocs.gz",
+                        "src/test/resources/data/human-pheno.assocs.gz")
+                .createKnowledgeBase();
 
     }
 

--- a/owlsim-core/src/test/java/org/monarchinitiative/owlsim/io/OntologySourceDataTest.java
+++ b/owlsim-core/src/test/java/org/monarchinitiative/owlsim/io/OntologySourceDataTest.java
@@ -1,0 +1,42 @@
+package org.monarchinitiative.owlsim.io;
+
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
+ */
+public class OntologySourceDataTest {
+
+    @Test
+    public void testItAll() {
+
+        Map<String, String> curies = new LinkedHashMap<>();
+        curies.put("HP", "http://purl.obolibrary.org/obo/HP_");
+        curies.put("MP", "http://purl.obolibrary.org/obo/MP_");
+        curies.put("NCBITaxon", "http://purl.obolibrary.org/obo/NCBITaxon_");
+
+        OntologySourceData sourceData = OntologySourceData.builder()
+                .curies(curies)
+                .ontology("src/test/resources/ontologies/mammal.obo.gz")
+                .dataTsv("src/test/resources/data/gene2taxon.tsv.gz")
+                .dataTsv("src/test/resources/data/mouse-pheno.assocs.gz")
+                .dataTsv("src/test/resources/data/human-pheno.assocs.gz")
+                .build();
+
+        System.out.println(sourceData);
+    }
+
+    @Test(expected = Exception.class)
+    public void testThrowsExceptionWhenCuriesEmptyAndDataIncludedFromTsv() {
+
+        OntologySourceData sourceData = OntologySourceData.builder()
+                .dataTsv("src/test/resources/data/gene2taxon.tsv.gz")
+                .build();
+
+        System.out.println(sourceData);
+    }
+
+}

--- a/owlsim-core/src/test/java/org/monarchinitiative/owlsim/io/OwlKnowledgeBaseTest.java
+++ b/owlsim-core/src/test/java/org/monarchinitiative/owlsim/io/OwlKnowledgeBaseTest.java
@@ -1,0 +1,169 @@
+package org.monarchinitiative.owlsim.io;
+
+import org.junit.Test;
+import org.monarchinitiative.owlsim.kb.BMKnowledgeBase;
+import uk.ac.manchester.cs.jfact.JFactFactory;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Utility class for creating a {@link BMKnowledgeBase} from input ontologies, curies and data. Ontologies can be in OWL
+ * or OBO format, gzipped or uncompressed.
+ * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
+ */
+public class OwlKnowledgeBaseTest {
+
+    private static final String SPECIES_OWL = "src/test/resources/species.owl";
+
+    private Map<String, String> curies() {
+        Map<String, String> curies = new LinkedHashMap<>();
+        curies.put("HP", "http://purl.obolibrary.org/obo/HP_");
+        curies.put("MP", "http://purl.obolibrary.org/obo/MP_");
+        curies.put("NCBITaxon", "http://purl.obolibrary.org/obo/NCBITaxon_");
+        return curies;
+    }
+
+    @Test
+    public void testLoadOwlFromFile() {
+        BMKnowledgeBase bmKnowledgeBase = OwlKnowledgeBase.loader()
+                .loadOntology(new File(SPECIES_OWL))
+                .createKnowledgeBase();
+    }
+
+    @Test
+    public void testLoadOwlWithIndividualsFromFilePath() {
+        BMKnowledgeBase bmKnowledgeBase = OwlKnowledgeBase.loader()
+                .loadOntology(SPECIES_OWL)
+                .createKnowledgeBase();
+        assertEquals(24, bmKnowledgeBase.getIndividualIdsInSignature().size());
+        //why -1? This is because http://www.w3.org/2002/07/owl#Thing is also reported as class.
+        assertEquals(77, bmKnowledgeBase.getClassIdsInSignature().size() - 1);
+    }
+
+    @Test
+    public void testLoadGzippedOboOntology() {
+        BMKnowledgeBase bmKnowledgeBase = OwlKnowledgeBase.loader()
+                .loadOntology("src/test/resources/ontologies/mammal.obo.gz")
+                .createKnowledgeBase();
+    }
+
+    @Test
+    public void testLoadOntologiesFromMultipleSources() {
+        BMKnowledgeBase bmKnowledgeBase = OwlKnowledgeBase.loader()
+                .loadOntologies(
+                        Arrays.asList("src/test/resources/species.owl",
+                        "http://purl.obolibrary.org/obo/aeo.owl",
+                        "src/test/resources/ontologies/mammal.obo.gz")
+                )
+                .createKnowledgeBase();
+    }
+
+    /**
+     * Ignored so as not to use network - this is a slow test
+     */
+//    @Ignore
+    @Test
+    public void testLoadRemoteOntology() {
+        BMKnowledgeBase bmKnowledgeBase = OwlKnowledgeBase.loader()
+                .loadOntology("http://purl.obolibrary.org/obo/aeo.owl")
+                .createKnowledgeBase();
+    }
+
+    @Test(expected = OntologyLoadException.class)
+    public void testLoadGzippedDataFileNoOntology() {
+        BMKnowledgeBase bmKnowledgeBase = OwlKnowledgeBase.loader()
+                .loadDataFromTsv("src/test/resources/data/human-pheno.assocs.gz")
+                .createKnowledgeBase();
+    }
+
+    @Test
+    public void loadDataFromOntology() {
+        BMKnowledgeBase bmKnowledgeBase = OwlKnowledgeBase.loader()
+                .loadOntology("src/test/resources/species.owl")
+                .loadCuries(curies())
+                .loadDataFromOntology("src/test/resources/species.owl")
+                .createKnowledgeBase();
+    }
+
+    @Test
+    public void loadDataFromOntologies() {
+        BMKnowledgeBase bmKnowledgeBase = OwlKnowledgeBase.loader()
+                .loadOntology("src/test/resources/ontologies/mammal.obo.gz")
+                .loadCuries(curies())
+                .loadDataFromOntologies("src/test/resources/mp-subset.ttl", "src/test/resources/mp-subset.ttl")
+                .createKnowledgeBase();
+    }
+
+    @Test
+    public void loadDataFromTsv() {
+        BMKnowledgeBase bmKnowledgeBase = OwlKnowledgeBase.loader()
+                .loadCuries(curies())
+                .loadOntology("src/test/resources/ontologies/mammal.obo.gz")
+                .loadDataFromTsv("src/test/resources/data/human-pheno.assocs.gz")
+                .createKnowledgeBase();
+    }
+
+    @Test
+    public void loadDataFromGzippedTsv() {
+        BMKnowledgeBase bmKnowledgeBase = OwlKnowledgeBase.loader()
+                .loadCuries(curies())
+                .loadOntology("src/test/resources/ontologies/mammal.obo.gz")
+                .loadDataFromTsv("src/test/resources/data/human-pheno.assocs.gz")
+                .createKnowledgeBase();
+    }
+
+    @Test
+    public void loadDataFromTsvCollection() {
+        BMKnowledgeBase bmKnowledgeBase = OwlKnowledgeBase.loader()
+                .loadCuries(curies())
+                .loadOntology("src/test/resources/ontologies/mammal.obo.gz")
+                .loadDataFromTsv(Arrays.asList(
+                        "src/test/resources/data/gene2taxon.tsv.gz",
+                        "src/test/resources/data/mouse-pheno.assocs.gz",
+                        "src/test/resources/data/human-pheno.assocs.gz"))
+                .createKnowledgeBase();
+
+        //|classes|=38627
+        //|individuals|=14200
+        //What should this be? It's different from the OWLLoader version.
+        //Turns out that without the correct curies the classes are not properly resolved so there will be 53630 classes
+        // without any curies. About 40,000-odd without the MP curie and 38629 without the NCBITaxon curie (1 mouse, 1
+        // human class).
+        //So remember folks, curies are good, especially with poppadums and beer.
+
+        //lastly, why -1? This is because http://www.w3.org/2002/07/owl#Thing is also reported as class.
+        assertEquals(38627, bmKnowledgeBase.getClassIdsInSignature().size() - 1);
+        assertEquals(14200, bmKnowledgeBase.getIndividualIdsInSignature().size());
+    }
+
+    @Test
+    public void testLoadOwlFromFileLocationWithStandardOntologyManager() throws Exception {
+        BMKnowledgeBase bmKnowledgeBase = OwlKnowledgeBase.loader()
+                .useStandardOntologyManager()
+                .loadOntology(SPECIES_OWL)
+                .createKnowledgeBase();
+    }
+
+    @Test
+    public void canSpecifyConcurrentOntologyManager() {
+        OwlKnowledgeBase.loader().useConcurrentOntologyManager();
+    }
+
+    @Test
+    public void canSpecifyStandardOntologyManager() {
+        OwlKnowledgeBase.loader().useStandardOntologyManager();
+    }
+
+    @Test
+    public void testUseOtherOwlReasonerFactory() throws Exception {
+        BMKnowledgeBase bmKnowledgeBase = OwlKnowledgeBase.loader()
+                .useReasonerFactory(new JFactFactory())
+                .loadOntology(SPECIES_OWL)
+                .createKnowledgeBase();
+    }
+}

--- a/owlsim-services/src/main/java/org/monarchinitiative/owlsim/services/OwlSimServiceApplication.java
+++ b/owlsim-services/src/main/java/org/monarchinitiative/owlsim/services/OwlSimServiceApplication.java
@@ -15,12 +15,18 @@
  */
 package org.monarchinitiative.owlsim.services;
 
-import java.util.EnumSet;
-import java.util.Set;
-
-import javax.servlet.DispatcherType;
-import javax.servlet.FilterRegistration;
-
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.common.reflect.ClassPath;
+import com.google.common.reflect.ClassPath.ClassInfo;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.dropwizard.Application;
+import io.dropwizard.assets.AssetsBundle;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.swagger.jaxrs.config.BeanConfig;
+import io.swagger.jaxrs.listing.ApiListingResource;
 import org.apache.log4j.Logger;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.monarchinitiative.owlsim.services.configuration.ApplicationConfiguration;
@@ -29,22 +35,13 @@ import org.monarchinitiative.owlsim.services.modules.KnowledgeBaseModule;
 import org.monarchinitiative.owlsim.services.modules.MatcherMapModule;
 import org.semanticweb.owlapi.OWLAPIParsersModule;
 import org.semanticweb.owlapi.OWLAPIServiceLoaderModule;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.google.common.reflect.ClassPath;
-import com.google.common.reflect.ClassPath.ClassInfo;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
-
-import io.dropwizard.Application;
-import io.dropwizard.assets.AssetsBundle;
-import io.dropwizard.setup.Bootstrap;
-import io.dropwizard.setup.Environment;
-import io.swagger.jaxrs.config.BeanConfig;
-import io.swagger.jaxrs.listing.ApiListingResource;
 import uk.ac.manchester.cs.owl.owlapi.OWLAPIImplModule;
 import uk.ac.manchester.cs.owl.owlapi.concurrent.Concurrency;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterRegistration;
+import java.util.EnumSet;
+import java.util.Set;
 
 public class OwlSimServiceApplication extends Application<ApplicationConfiguration> {
 
@@ -146,7 +143,7 @@ public class OwlSimServiceApplication extends Application<ApplicationConfigurati
 				new KnowledgeBaseModule(configuration.getOntologyUris(), configuration.getOntologyDataUris(),
 						configuration.getDataTsvs(), configuration.getCuries()),
 				new EnrichmentMapModule(), new MatcherMapModule());
-		LOG.info("BINDINGS =" + i.getAllBindings());
+		//removed binding info as this caused things to explode. Wasn't helpful.
 		// Add resources
 		Set<ClassInfo> resourceClasses = ClassPath.from(getClass().getClassLoader())
 				.getTopLevelClasses("org.monarchinitiative.owlsim.services.resources");

--- a/owlsim-services/src/main/java/org/monarchinitiative/owlsim/services/modules/KnowledgeBaseModule.java
+++ b/owlsim-services/src/main/java/org/monarchinitiative/owlsim/services/modules/KnowledgeBaseModule.java
@@ -1,57 +1,28 @@
 package org.monarchinitiative.owlsim.services.modules;
 
-import com.google.common.collect.ImmutableCollection;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import org.apache.commons.validator.routines.UrlValidator;
-import org.jboss.logging.Logger;
+import org.apache.log4j.Logger;
 import org.monarchinitiative.owlsim.compute.classmatch.ClassMatcher;
 import org.monarchinitiative.owlsim.compute.enrich.impl.HypergeometricEnrichmentEngine;
 import org.monarchinitiative.owlsim.compute.matcher.impl.BayesianNetworkProfileMatcher;
 import org.monarchinitiative.owlsim.compute.mica.MostInformativeCommonAncestorCalculator;
 import org.monarchinitiative.owlsim.compute.mica.impl.MostInformativeCommonAncestorCalculatorImpl;
+import org.monarchinitiative.owlsim.io.OwlKnowledgeBase;
 import org.monarchinitiative.owlsim.kb.BMKnowledgeBase;
-import org.monarchinitiative.owlsim.kb.impl.BMKnowledgeBaseOWLAPIImpl;
-import org.monarchinitiative.owlsim.services.modules.bindings.IndicatesDataTsvs;
-import org.monarchinitiative.owlsim.services.modules.bindings.IndicatesOwlDataOntologies;
-import org.monarchinitiative.owlsim.services.modules.bindings.IndicatesOwlOntologies;
-import org.prefixcommons.CurieUtil;
-import org.semanticweb.elk.owlapi.ElkReasonerFactory;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
-import org.semanticweb.owlapi.model.OWLOntologyManager;
-import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 
-import java.io.*;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-import java.util.zip.GZIPInputStream;
 
-/**
- * TODO: Uncomment the OwlKnowledgeBase code and remove unecessary code once happy.
- */
 public class KnowledgeBaseModule extends AbstractModule {
 
 	Logger logger = Logger.getLogger(KnowledgeBaseModule.class);
 
-	private final ImmutableCollection<String> ontologyUris;
-	private final ImmutableCollection<String> ontologyDataUris;
-	private final ImmutableCollection<String> dataTsvs;
-	private final ImmutableMap<String, String> curies;
-	private final UrlValidator urlValdiator = UrlValidator.getInstance();
-
-//	private final BMKnowledgeBase bmKnowledgeBase;
+	private final BMKnowledgeBase bmKnowledgeBase;
 
 	public KnowledgeBaseModule(Collection<String> ontologyUris, Collection<String> ontologyDataUris, Set<String> dataTsvs, Map<String, String> curies) {
-		this.ontologyUris = new ImmutableSet.Builder<String>().addAll(ontologyUris).build();
-		this.ontologyDataUris = new ImmutableSet.Builder<String>().addAll(ontologyDataUris).build();
-		this.dataTsvs = new ImmutableSet.Builder<String>().addAll(dataTsvs).build();
-		this.curies = new ImmutableMap.Builder<String, String>().putAll(curies).build();
 
 		logger.info("Loading ontologyUris:");
 		ontologyUris.forEach(logger::info);
@@ -62,90 +33,27 @@ public class KnowledgeBaseModule extends AbstractModule {
 		logger.info("Loading curies:");
 		curies.entrySet().forEach(logger::info);
 
-//		//The OwlKnowledgeBase.Loader uses the ELKReasonerFactory and Concurrency.CONCURRENT as defaults.
-//		this.bmKnowledgeBase = OwlKnowledgeBase.loader()
-//				.loadOntologies(ontologyUris)
-//				.loadDataFromOntologies(ontologyDataUris)
-//				.loadDataFromTsv(dataTsvs)
-//				.loadCuries(curies)
-//				.createKnowledgeBase();
-//
-//		logger.info("Created BMKnowledgebase");
+		//The OwlKnowledgeBase.Loader uses the ELKReasonerFactory and Concurrency.CONCURRENT as defaults.
+		this.bmKnowledgeBase = OwlKnowledgeBase.loader()
+				.loadOntologies(ontologyUris)
+				.loadDataFromOntologies(ontologyDataUris)
+				.loadDataFromTsv(dataTsvs)
+				.loadCuries(curies)
+				.createKnowledgeBase();
+
+		logger.info("Created BMKnowledgebase");
 	}
 
 	@Override
 	protected void configure() {
-		bind(BMKnowledgeBase.class).to(BMKnowledgeBaseOWLAPIImpl.class).in(Singleton.class);
-		bind(OWLReasonerFactory.class).to(ElkReasonerFactory.class);
-		bind(CurieUtil.class).toInstance(new CurieUtil(curies));
-
-		// bind(OWLOntologyManager.class).to(OWLOntologyManagerImpl.class);
-		// bind(ReadWriteLock.class).to(NoOpReadWriteLock.class);
-		// bind(OWLDataFactory.class).to(OWLDataFactoryImpl.class);
-		// bind(OWLOntologyManager.class).toInstance(OWLManager.createOWLOntologyManager());
-	}
-
-//	@Provides
-//	BMKnowledgeBase provideBMKnowledgeBaseOWLAPIImpl() {
-//		return bmKnowledgeBase;
-//	}
-
-	@Provides
-	BMKnowledgeBaseOWLAPIImpl provideBMKnowledgeBaseOWLAPIImpl(@IndicatesOwlOntologies OWLOntology owlOntology,
-			@IndicatesOwlDataOntologies OWLOntology owlDataOntology, OWLReasonerFactory rf, CurieUtil curieUtil) {
-		return new BMKnowledgeBaseOWLAPIImpl(owlOntology,owlDataOntology, rf, curieUtil);
-	}
-
-	OWLOntology loadOntology(OWLOntologyManager manager, String uri) throws OWLOntologyCreationException {
-		if (urlValdiator.isValid(uri)) {
-			return manager.loadOntology(IRI.create(uri));
-		} else {
-			File file = new File(uri);
-			return manager.loadOntologyFromOntologyDocument(file);
-		}
-	}
-
-	OWLOntology mergeOntologies(OWLOntologyManager manager, Collection<String> uris)
-			throws OWLOntologyCreationException, FileNotFoundException, IOException {
-		OWLOntology ontology = manager.createOntology();
-		for (String uri : uris) {
-			OWLOntology loadedOntology;
-			if (uri.endsWith(".gz")) {
-				GZIPInputStream gis = new GZIPInputStream(new FileInputStream(uri));
-				BufferedReader bf = new BufferedReader(new InputStreamReader(gis, "UTF-8"));
-				loadedOntology = manager.loadOntologyFromOntologyDocument(gis);
-			} else {
-				loadedOntology = loadOntology(manager, uri);
-			}
-			manager.addAxioms(ontology, loadedOntology.getAxioms());
-		}
-		return ontology;
 	}
 
 	@Provides
-	@IndicatesOwlOntologies
 	@Singleton
-	OWLOntology getOwlOntologies(OWLOntologyManager manager)
-			throws OWLOntologyCreationException, FileNotFoundException, IOException {
-		return mergeOntologies(manager, ontologyUris);
+	BMKnowledgeBase provideBMKnowledgeBaseOWLAPIImpl() {
+		return bmKnowledgeBase;
 	}
 
-	@Provides
-	@IndicatesOwlDataOntologies
-	@Singleton
-	OWLOntology getOwlDataOntologies(OWLOntologyManager manager)
-			throws OWLOntologyCreationException, FileNotFoundException, IOException {
-		return mergeOntologies(manager, ontologyDataUris);
-	}
-
-	@Provides
-	@IndicatesDataTsvs
-	@Singleton
-	OWLOntology getDataTsvs(OWLOntologyManager manager)
-			throws OWLOntologyCreationException, FileNotFoundException, IOException {
-		return mergeOntologies(manager, dataTsvs);
-	}
-	
 	@Provides
 	MostInformativeCommonAncestorCalculator getMostInformativeCommonAncestorCalculator(BMKnowledgeBase knowledgeBase) {
         return new MostInformativeCommonAncestorCalculatorImpl(knowledgeBase);

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>18.0</version>
+			<version>21.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>


### PR DESCRIPTION
Added a bunch of code/deprecated OWLLoader towards #57 

Code is hopefully self-documenting, using a fluid API. For example, in the KnowldegBaseModule:

```
    //The OwlKnowledgeBase.Loader uses the ELKReasonerFactory and Concurrency.CONCURRENT as defaults. 
    this.bmKnowledgeBase = OwlKnowledgeBase.loader()
        .loadOntologies(ontologyUris) 
        .loadDataFromOntologies(ontologyDataUris)
        .loadDataFromTsv(dataTsvs) 
        .loadCuries(curies)
        .createKnowledgeBase(); 

    logger.info("Created BMKnowledgebase"); 
```

There is one possible issue though - the server didn't start. I'm not sure if I screwed up some Guice magic or not, but getting rid of the injector.getAllBindings() logger statement allowed the server to start and superficially appears to work.